### PR TITLE
iterator#next and iterator#end should not throw if there is a callback

### DIFF
--- a/abstract/iterator-test.js
+++ b/abstract/iterator-test.js
@@ -58,29 +58,27 @@ module.exports.args = function (test) {
 }
 
 module.exports.sequence = function (test) {
-  test('test twice iterator#end() throws', function (t) {
+  test('test twice iterator#end() callback with error', function (t) {
     var iterator = db.iterator()
     iterator.end(function (err) {
       t.notOk(err, 'no error')
-      t.throws(
-          iterator.end.bind(iterator, function () {})
-        , { name: 'Error', message: 'end() already called on iterator' }
-        , 'no-arg iterator#next() throws'
-      )
-      t.end()
+      iterator.end(function(err2) {
+        var expected = { name: 'Error', message: 'end() already called on iterator' }
+        t.deepEqual(err2, expected, 'error expected in the callback')
+        t.end()
+      })
     })
   })
 
-  test('test iterator#next after iterator#end() throws', function (t) {
+  test('test iterator#next after iterator#end() callback with error', function (t) {
     var iterator = db.iterator()
     iterator.end(function (err) {
       t.notOk(err, 'no error')
-      t.throws(
-          iterator.next.bind(iterator, function () {})
-        , { name: 'Error', message: 'cannot call next() after end()' }
-        , 'no-arg iterator#next() after iterator#end() throws'
-      )
-      t.end()
+      iterator.next(function(err2) {
+        var expected = { name: 'Error', message: 'cannot call next() after end()' }
+        t.deepEqual(err2, expected, 'error expected in the callback')
+        t.end()
+      })
     })
   })
 
@@ -93,11 +91,11 @@ module.exports.sequence = function (test) {
         t.end()
       })
     })
-    t.throws(
-        iterator.next.bind(iterator, function () {})
-      , { name: 'Error', message: 'cannot call next() before previous next() has completed' }
-      , 'no-arg iterator#next() throws'
-    )
+    iterator.next(function(err) {
+      var expected = { name: 'Error', message: 'cannot call next() before previous next() has completed' }
+      t.deepEqual(err, expected, 'error expected in the callback')
+      t.end()
+    })
   })
 }
 


### PR DESCRIPTION
In the `iterator-test.js` is specified that if `next` is called after `end`, then it should _throw_ an exception, instead of passing through the callback, as in the node callback style.
This causes the ReadStream in LevelUp not to emit `error` accordingly.

You can find an example of the behavior here: https://gist.github.com/mcollina/5544554.
It should be expected that the error is logged, instead it halts the program.

These are the lines in abstract-leveldown:
https://github.com/rvagg/node-abstract-leveldown/blob/master/abstract/iterator-test.js#L74-L85

And these in leveldown:
https://github.com/rvagg/node-leveldown/blob/master/src/iterator.cc#L138-L144

And these in levelup:
https://github.com/rvagg/node-levelup/blob/master/lib/read-stream.js#L121-L126

This can be fixed in leveldown, or the call to `next` wrapped in a try-catch in LevelUp.
I think it should be fixed in LevelDown.

I have a patch ready for LevelDown.
@rvagg @dominictarr let me know how to proceed.
