### PR TITLE
added chained batch form

### DIFF
--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -1,0 +1,47 @@
+/* Copyright (c) 2013 Rod Vagg, MIT License */
+
+function AbstractChainedBatch (db) {
+  this._db         = db
+  this._operations = []
+}
+
+AbstractChainedBatch.prototype.put = function (key, value) {
+  var err = this._db._checkKeyValue(key, 'key', this._db._isBuffer)
+  if (err) throw err
+  err = this._db._checkKeyValue(value, 'value', this._db._isBuffer)
+  if (err) throw err
+
+  if (!this._db._isBuffer(key)) key = String(key)
+  if (!this._db._isBuffer(value)) value = String(value)
+
+  this._operations.push({ type: 'put', key: key, value: value })
+
+  return this
+}
+
+AbstractChainedBatch.prototype.del = function (key) {
+  var err = this._db._checkKeyValue(key, 'key', this._db._isBuffer)
+  if (err) throw err
+
+  if (!this._db._isBuffer(key)) key = String(key)
+
+  this._operations.push({ type: 'del', key: key })
+
+  return this
+}
+
+AbstractChainedBatch.prototype.write = function (options, callback) {
+  if (typeof options == 'function')
+    callback = options
+  if (typeof callback != 'function')
+    throw new Error('write() requires a callback argument')
+  if (typeof options != 'object')
+    options = {}
+
+  if (typeof this._db._batch == 'function')
+    return this._db._batch(this._operations, options, callback)
+
+  process.nextTick(callback)
+}
+
+module.exports = AbstractChainedBatch

--- a/abstract-iterator.js
+++ b/abstract-iterator.js
@@ -1,0 +1,47 @@
+/* Copyright (c) 2013 Rod Vagg, MIT License */
+
+function AbstractIterator (db) {
+  this.db = db
+  this._ended = false
+  this._nexting = false
+}
+
+AbstractIterator.prototype.next = function (callback) {
+  if (typeof callback != 'function')
+    throw new Error('next() requires a callback argument')
+
+  if (this._ended)
+    throw new Error('cannot call next() after end()')
+  if (this._nexting)
+    throw new Error('cannot call next() before previous next() has completed')
+
+  this._nexting = true
+  if (typeof this._next == 'function') {
+    return this._next(function () {
+      this._nexting = false
+      callback.apply(null, arguments)
+    }.bind(this))
+  }
+
+  process.nextTick(function () {
+    this._nexting = false
+    callback()
+  }.bind(this))
+}
+
+AbstractIterator.prototype.end = function (callback) {
+  if (typeof callback != 'function')
+    throw new Error('end() requires a callback argument')
+
+  if (this._ended)
+    throw new Error('end() already called on iterator')
+
+  this._ended = true
+
+  if (typeof this._end == 'function')
+    return this._end(callback)
+
+  process.nextTick(callback)
+}
+
+module.exports = AbstractIterator

--- a/abstract/batch-test.js
+++ b/abstract/batch-test.js
@@ -1,0 +1,126 @@
+var db
+
+module.exports.setUp = function (leveldown, test, testCommon) {
+  test('setUp common', testCommon.setUp)
+  test('setUp db', function (t) {
+    db = leveldown(testCommon.location())
+    db.open(t.end.bind(t))
+  })
+}
+
+module.exports.args = function (test) {
+  test('test callback-less, 2-arg, batch() throws', function (t) {
+    t.throws(db.batch.bind(db, 'foo', {}), 'callback-less, 2-arg batch() throws')
+    t.end()
+  })
+
+  test('test batch() with missing `value`', function (t) {
+    db.batch([{ type: 'put', key: 'foo1' }], function (err) {
+      t.like(err.message, /value cannot be `null` or `undefined`/, 'correct error message')
+      t.end()
+    })
+  })
+
+  test('test batch() with null `value`', function (t) {
+    db.batch([{ type: 'put', key: 'foo1', value: null }], function (err) {
+      console.error('err', err)
+      t.like(err.message, /value cannot be `null` or `undefined`/, 'correct error message')
+      t.end()
+    })
+  })
+
+  test('test batch() with missing `key`', function (t) {
+    db.batch([{ type: 'put', value: 'foo1' }], function (err) {
+      t.like(err.message, /key cannot be `null` or `undefined`/, 'correct error message')
+      t.end()
+    })
+  })
+
+  test('test batch() with null `key`', function (t) {
+    db.batch([{ type: 'put', key: null, value: 'foo1' }], function (err) {
+      t.like(err.message, /key cannot be `null` or `undefined`/, 'correct error message')
+      t.end()
+    })
+  })
+
+  test('test batch() with missing `key` and `value`', function (t) {
+    db.batch([{ type: 'put' }], function (err) {
+      t.like(err.message, /key cannot be `null` or `undefined`/, 'correct error message')
+      t.end()
+    })
+  })
+}
+
+module.exports.batch = function (test) {
+  test('test batch() with empty array', function (t) {
+    db.batch([], function (err) {
+      t.notOk(err, 'no error')
+      t.end()
+    })
+  })
+
+  test('test simple batch()', function (t) {
+    db.batch([{ type: 'put', key: 'foo', value: 'bar' }], function (err) {
+      t.notOk(err, 'no error')
+
+      db.get('foo', function (err, value) {
+        t.notOk(err, 'no error')
+        t.type(value, Buffer)
+        t.equal(value.toString(), 'bar')
+
+        t.end()
+      })
+    })
+  })
+
+  test('test multiple batch()', function (t) {
+    db.batch([
+        { type: 'put', key: 'foobatch1', value: 'bar1' }
+      , { type: 'put', key: 'foobatch2', value: 'bar2' }
+      , { type: 'put', key: 'foobatch3', value: 'bar3' }
+      , { type: 'del', key: 'foobatch2' }
+    ], function (err) {
+      t.notOk(err, 'no error')
+
+      var r = 0
+        , done = function () {
+            if (++r == 3)
+              t.end()
+          }
+
+      db.get('foobatch1', function (err, value) {
+        t.notOk(err, 'no error')
+        t.type(value, Buffer)
+        t.equal(value.toString(), 'bar1')
+        done()
+      })
+
+      db.get('foobatch2', function (err, value) {
+        t.ok(err, 'entry not found')
+        t.notOk(value, 'value not returned')
+        t.like(err.message, /NotFound/)
+        done()
+      })
+
+      db.get('foobatch3', function (err, value) {
+        t.notOk(err, 'no error')
+        t.type(value, Buffer)
+        t.equal(value.toString(), 'bar3')
+        done()
+      })
+    })
+  })
+}
+
+module.exports.tearDown = function (test, testCommon) {
+  test('tearDown', function (t) {
+    db.close(testCommon.tearDown.bind(null, t))
+  })
+}
+
+module.exports.all = function (leveldown, test, testCommon) {
+  module.exports.setUp(leveldown, test, testCommon)
+  module.exports.args(test)
+  module.exports.batch(test)
+  module.exports.tearDown(test, testCommon)
+}

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -1,0 +1,152 @@
+var db
+
+module.exports.setUp = function (leveldown, test, testCommon) {
+  test('setUp common', testCommon.setUp)
+  test('setUp db', function (t) {
+    db = leveldown(testCommon.location())
+    db.open(t.end.bind(t))
+  })
+}
+
+module.exports.args = function (test) {
+  test('test batch#put() with missing `value`', function (t) {
+    try {
+      db.batch().put('foo1')
+    } catch (err) {
+      t.equal(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+
+  test('test batch#put() with null `value`', function (t) {
+    try {
+      db.batch().put('foo1', null)
+    } catch (err) {
+      t.equal(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+
+  test('test batch#put() with missing `key`', function (t) {
+    try {
+      db.batch().put(undefined, 'foo1')
+    } catch (err) {
+      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+
+  test('test batch#put() with null `key`', function (t) {
+    try {
+      db.batch().put(null, 'foo1')
+    } catch (err) {
+      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+
+  test('test batch#put() with missing `key` and `value`', function (t) {
+    try {
+      db.batch().put()
+    } catch (err) {
+      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+
+  test('test batch#del() with missing `key`', function (t) {
+    try {
+      db.batch().del()
+    } catch (err) {
+      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+
+  test('test batch#del() with null `key`', function (t) {
+    try {
+      db.batch().del(null)
+    } catch (err) {
+      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+
+  test('test batch#del() with null `key`', function (t) {
+    try {
+      db.batch().del(null)
+    } catch (err) {
+      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+
+  test('test batch#write() with no callback', function (t) {
+    try {
+      db.batch().write()
+    } catch (err) {
+      t.equal(err.message, 'write() requires a callback argument', 'correct error message')
+      return t.end()
+    }
+    t.fail('should have thrown')
+  })
+}
+
+module.exports.batch = function (test, testCommon) {
+  test('basic batch', function (t) {
+    db.batch(
+        [
+            { type: 'put', key: 'one', value: '1' }
+          , { type: 'put', key: 'two', value: '2' }
+          , { type: 'put', key: 'three', value: '3' }
+        ]
+      , function (err) {
+          t.notOk(err, 'no error')
+
+          db.batch()
+            .put('one', 'I')
+            .put('two', 'II')
+            .del('three')
+            .put('foo', 'bar')
+            .write(function (err) {
+              t.notOk(err, 'no error')
+              testCommon.collectEntries(
+                  db.iterator({ keyAsBuffer: false, valueAsBuffer: false })
+                , function (err, data) {
+                    t.notOk(err, 'no error')
+                    t.equal(data.length, 3, 'correct number of entries')
+                    var expected = [
+                        { key: 'foo', value: 'bar' }
+                      , { key: 'one', value: 'I' }
+                      , { key: 'two', value: 'II' }
+                    ]
+                    t.deepEqual(data, expected)
+                    t.end()
+                  }
+              )
+            })
+        }
+    )
+  })
+}
+
+module.exports.tearDown = function (test, testCommon) {
+  test('tearDown', function (t) {
+    db.close(testCommon.tearDown.bind(null, t))
+  })
+}
+
+module.exports.all = function (leveldown, test, testCommon) {
+  module.exports.setUp(leveldown, test, testCommon)
+  module.exports.args(test)
+  module.exports.batch(test, testCommon)
+  module.exports.tearDown(test, testCommon)
+}


### PR DESCRIPTION
For review by @juliangruber, @maxogden, @No9 (and anyone else that wants to get their eyes dirty).

Adds the chained batch form to AbstractLevelDOWN by adding a new AbstractChainedBatch object that is returned if you call an argument-less `batch()`. That object has `put()`, `del()` and `write()` and will default to collecting the elements and submitting them back to `db._batch(array, options, callback)`. So, if your implementing package (level.js, leveldown-gap, memdown) does a proper `_batch()` then it should just be a matter of upgrading to this version of AbstractLevelDOWN and you get the chained batch syntax free.

That's the theory anyway and supposedly what the tests say, I haven't actually put this into use in MemDOWN yet but that'll be interesting.
