### PR TITLE
tests: have the error message correspond with the BufferType

### DIFF
--- a/abstract/put-get-del-test.js
+++ b/abstract/put-get-del-test.js
@@ -98,7 +98,7 @@ module.exports.errorKeys = function (testFunc, BufferType) {
   makeErrorKeyTest('null key', null, /key cannot be `null` or `undefined`/)
   makeErrorKeyTest('undefined key', undefined, /key cannot be `null` or `undefined`/)
   makeErrorKeyTest('empty String key', '', /key cannot be an empty String/)
-  makeErrorKeyTest('empty Buffer key', new BufferType(0), /key cannot be an empty Buffer/)
+  makeErrorKeyTest('empty Buffer key', new BufferType(0), /key cannot be an empty \w*Buffer/)
   makeErrorKeyTest('empty Array key', [], /key cannot be an empty String/)
 }
 
@@ -136,7 +136,7 @@ module.exports.errorValues = function (testFunc, BufferType) {
   makePutErrorTest('null value', 'foo', null, /value cannot be `null` or `undefined`/)
   makePutErrorTest('undefined value', 'foo', undefined, /value cannot be `null` or `undefined`/)
   makePutErrorTest('empty String value', 'foo', '', /value cannot be an empty String/)
-  makePutErrorTest('empty Buffer value', 'foo', new BufferType(0), /value cannot be an empty Buffer/)
+  makePutErrorTest('empty Buffer value', 'foo', new BufferType(0), /value cannot be an empty \w*Buffer/)
   makePutErrorTest('empty Array value', 'foo', [], /value cannot be an empty String/)
 }
 


### PR DESCRIPTION
Hi! I'm working on updating level.js, specifically getting all the tests in maxogden/level.js#19 to pass. Some of the tests are incorrectly failing because the error message will check for `'Buffer'` even though the buffer type is `ArrayBuffer`. This will switch the error message to the corresponding buffer type.
