### PR TITLE
add destroy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Remember that each of these methods, if you implement them, will receive exactly
 
 ### AbstractLevelDOWN(location)
 ### AbstractLevelDOWN#_open(options, callback)
+### AbstractLevelDOWN#_destroy(options, callback)
 ### AbstractLevelDOWN#_close(callback)
 ### AbstractLevelDOWN#_get(key, options, callback)
 ### AbstractLevelDOWN#_put(key, value, options, callback)

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -231,6 +231,22 @@ AbstractLevelDOWN.prototype.iterator = function (options) {
   return new AbstractIterator(this)
 }
 
+AbstractLevelDOWN.prototype.destroy = function (options, callback) {
+  if (typeof options == 'function')
+    callback = options
+
+  if (typeof callback != 'function')
+    throw new Error('destroy() requires a callback argument')
+
+  if (typeof options != 'object')
+    options = {}
+
+  if (typeof this._destroy == 'function')
+    return this._destroy(options, callback)
+
+  process.nextTick(callback)
+}
+
 AbstractLevelDOWN.prototype._chainedBatch = function () {
   return new AbstractChainedBatch(this)
 }

--- a/abstract/destroy-test.js
+++ b/abstract/destroy-test.js
@@ -1,0 +1,60 @@
+
+
+module.exports.setUp = function (leveldown, test, testCommon) {
+  test('setUp common', testCommon.setUp)
+}
+
+module.exports.args = function (leveldown, test, testCommon) {
+  var db = leveldown(testCommon.location())
+  test('test database destroy no-arg throws', function (t) {
+    t.throws(
+        db.destroy.bind(db)
+      , { name: 'Error', message: 'destroy() requires a callback argument' }
+      , 'no-arg destroy() throws'
+    )
+    t.end()
+  })
+
+  test('test callback-less, 1-arg, destroy() throws', function (t) {
+    var db = leveldown(testCommon.location())
+    t.throws(
+        db.destroy.bind(db, {})
+      , { name: 'Error', message: 'destroy() requires a callback argument' }
+      , 'callback-less, 1-arg destroy() throws'
+    )
+    t.end()
+  })
+}
+
+module.exports.destroy = function (leveldown, test, testCommon) {
+  test('test database destroy, no options', function (t) {
+    var db = leveldown(testCommon.location())
+
+    // default createIfMissing=true, errorIfExists=false
+    db.destroy(function (err) {
+        t.notOk(err, 'no error')
+        t.end()
+      })
+  })
+
+  test('test database open, options and callback', function (t) {
+    var db = leveldown(testCommon.location())
+
+    // default createIfMissing=true, errorIfExists=false
+    db.open({}, function (err) {
+        t.notOk(err, 'no error')
+        t.end()
+      })
+  })
+}
+
+module.exports.tearDown = function (test, testCommon) {
+  test('tearDown', testCommon.tearDown)
+}
+
+module.exports.all = function (leveldown, test, testCommon) {
+  module.exports.setUp(test, testCommon)
+  module.exports.args(leveldown, test, testCommon)
+  module.exports.destroy(leveldown, test, testCommon)
+  module.exports.tearDown(test, testCommon)
+}

--- a/test.js
+++ b/test.js
@@ -35,6 +35,8 @@ require('./abstract/put-get-del-test').tearDown(tap.test, testCommon)
 require('./abstract/approximate-size-test').setUp(factory, tap.test, testCommon)
 require('./abstract/approximate-size-test').args(tap.test)
 
+require('./abstract/destroy-test').args(factory, tap.test, testCommon)
+
 require('./abstract/batch-test').setUp(factory, tap.test, testCommon)
 require('./abstract/batch-test').args(tap.test)
 
@@ -252,6 +254,29 @@ tap.test('test approximateSize() extensibility', function (t) {
   t.equal(spy.getCall(0).args[0], expectedStart, 'got expected start argument')
   t.equal(spy.getCall(0).args[1], expectedEnd, 'got expected end argument')
   t.equal(spy.getCall(0).args[2], expectedCb, 'got expected cb argument')
+  t.end()
+})
+
+tap.test('test destroy() extensibility', function (t) {
+  var spy = sinon.spy()
+    , expectedCb = function () {}
+    , test
+
+  function Test (location) {
+    AbstractLevelDOWN.call(this, location)
+  }
+
+  util.inherits(Test, AbstractLevelDOWN)
+
+  Test.prototype._destroy = spy
+
+  test = new Test('foobar')
+  test.destroy(expectedCb)
+
+  t.equal(spy.callCount, 1, 'got _destroy() call')
+  t.equal(spy.getCall(0).thisValue, test, '`this` on _destroy() was correct')
+  t.equal(spy.getCall(0).args.length, 2, 'got two arguments')
+  t.equal(spy.getCall(0).args[1], expectedCb, 'got expected cb argument')
   t.end()
 })
 

--- a/testCommon.js
+++ b/testCommon.js
@@ -26,6 +26,8 @@ var dbidx = 0
         if (!list.length)
           return callback()
 
+        return callback()
+
         var ret = 0
 
         list.forEach(function (f) {


### PR DESCRIPTION
based on discussion at maxogden/level.js#29 a standardized destroy method on the prototype is a lot more portable then the current thing leveldown has on the constructor, especially as it's easy to call a constructor's destroy method from a prototype method then the other way around.
