### PR TITLE
update xtend to ~3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "main": "./abstract-leveldown.js",
   "dependencies": {
-    "xtend": "~2.1.1"
+    "xtend": "~3.0.0"
   },
   "devDependencies": {
     "tap": "*",


### PR DESCRIPTION
I know this seems like a trivial pull request but I'm working on packaging up [Groove Basin](https://github.com/andrewrk/groovebasin/) for Debian, which indirectly depends on the `xtend` module twice, with conflicting versions. NPM handles these version conflicts by simultaneously depending on multiple versions, while Debian requires that there be only one version of everything for security reasons. Fortunately, the solution is simple - if `abstract-leveldown` updates to the latest version of `xtend` then everybody is happy.

I have verified that the tests still pass. I would be grateful if you merged this and published a new version.
