### PR TITLE
remove options.start hackery

### DIFF
--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -208,20 +208,6 @@ AbstractLevelDOWN.prototype._setupIteratorOptions = function (options) {
   options.keyAsBuffer = 'keyAsBuffer' in options ? !!options.keyAsBuffer : true
   options.valueAsBuffer = 'valueAsBuffer' in options ? !!options.valueAsBuffer : true
 
-  // fix `start` so it takes into account gt, gte, lt, lte as appropriate
-  if (options.reverse && options.lt)
-    options.start = options.lt
-  if (options.reverse && options.lte)
-    options.start = options.lte
-  if (!options.reverse && options.gt)
-    options.start = options.gt
-  if (!options.reverse && options.gte)
-    options.start = options.gte
-
-  if ((options.reverse && options.lt && !options.lte)
-    || (!options.reverse && options.gt && !options.gte))
-    options.exclusiveStart = true // start should *not* include matching key
-
   return options
 }
 


### PR DESCRIPTION
This block came in @ 7fa27a77 and my guess is that it was to help transition to gte, gt, lte, lt but what it does is introduce a `'start'` option where there was none to begin with, it shouldn't molest the `options` in this way and pass through proper handling of this stuff to the backends.

Plus, we should deprecate `'start'` and `'end'` at some point to get rid of the confusion.
