### PR TITLE
Normalize usage of equal operators

### DIFF
--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -21,7 +21,7 @@ AbstractChainedBatch.prototype.put = function (key, value) {
   if (!this._db._isBuffer(key)) key = String(key)
   if (!this._db._isBuffer(value)) value = String(value)
 
-  if (typeof this._put == 'function' )
+  if (typeof this._put === 'function' )
     this._put(key, value)
   else
     this._operations.push({ type: 'put', key: key, value: value })
@@ -37,7 +37,7 @@ AbstractChainedBatch.prototype.del = function (key) {
 
   if (!this._db._isBuffer(key)) key = String(key)
 
-  if (typeof this._del == 'function' )
+  if (typeof this._del === 'function' )
     this._del(key)
   else
     this._operations.push({ type: 'del', key: key })
@@ -50,7 +50,7 @@ AbstractChainedBatch.prototype.clear = function () {
 
   this._operations = []
 
-  if (typeof this._clear == 'function' )
+  if (typeof this._clear === 'function' )
     this._clear()
 
   return this
@@ -59,19 +59,19 @@ AbstractChainedBatch.prototype.clear = function () {
 AbstractChainedBatch.prototype.write = function (options, callback) {
   this._checkWritten()
 
-  if (typeof options == 'function')
+  if (typeof options === 'function')
     callback = options
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('write() requires a callback argument')
-  if (typeof options != 'object')
+  if (typeof options !== 'object')
     options = {}
 
   this._written = true
 
-  if (typeof this._write == 'function' )
+  if (typeof this._write === 'function' )
     return this._write(callback)
 
-  if (typeof this._db._batch == 'function')
+  if (typeof this._db._batch === 'function')
     return this._db._batch(this._operations, options, callback)
 
   process.nextTick(callback)

--- a/abstract-iterator.js
+++ b/abstract-iterator.js
@@ -9,7 +9,7 @@ function AbstractIterator (db) {
 AbstractIterator.prototype.next = function (callback) {
   var self = this
 
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('next() requires a callback argument')
 
   if (self._ended)
@@ -18,7 +18,7 @@ AbstractIterator.prototype.next = function (callback) {
     return callback(new Error('cannot call next() before previous next() has completed'))
 
   self._nexting = true
-  if (typeof self._next == 'function') {
+  if (typeof self._next === 'function') {
     return self._next(function () {
       self._nexting = false
       callback.apply(null, arguments)
@@ -32,7 +32,7 @@ AbstractIterator.prototype.next = function (callback) {
 }
 
 AbstractIterator.prototype.end = function (callback) {
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('end() requires a callback argument')
 
   if (this._ended)
@@ -40,7 +40,7 @@ AbstractIterator.prototype.end = function (callback) {
 
   this._ended = true
 
-  if (typeof this._end == 'function')
+  if (typeof this._end === 'function')
     return this._end(callback)
 
   process.nextTick(callback)

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -8,33 +8,33 @@ function AbstractLevelDOWN (location) {
   if (!arguments.length || location === undefined)
     throw new Error('constructor requires at least a location argument')
 
-  if (typeof location != 'string')
+  if (typeof location !== 'string')
     throw new Error('constructor requires a location string argument')
 
   this.location = location
 }
 
 AbstractLevelDOWN.prototype.open = function (options, callback) {
-  if (typeof options == 'function')
+  if (typeof options === 'function')
     callback = options
 
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('open() requires a callback argument')
 
-  if (typeof options != 'object')
+  if (typeof options !== 'object')
     options = {}
 
-  if (typeof this._open == 'function')
+  if (typeof this._open === 'function')
     return this._open(options, callback)
 
   process.nextTick(callback)
 }
 
 AbstractLevelDOWN.prototype.close = function (callback) {
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('close() requires a callback argument')
 
-  if (typeof this._close == 'function')
+  if (typeof this._close === 'function')
     return this._close(callback)
 
   process.nextTick(callback)
@@ -43,10 +43,10 @@ AbstractLevelDOWN.prototype.close = function (callback) {
 AbstractLevelDOWN.prototype.get = function (key, options, callback) {
   var err
 
-  if (typeof options == 'function')
+  if (typeof options === 'function')
     callback = options
 
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('get() requires a callback argument')
 
   if (err = this._checkKey(key, 'key', this._isBuffer))
@@ -55,10 +55,10 @@ AbstractLevelDOWN.prototype.get = function (key, options, callback) {
   if (!this._isBuffer(key))
     key = String(key)
 
-  if (typeof options != 'object')
+  if (typeof options !== 'object')
     options = {}
 
-  if (typeof this._get == 'function')
+  if (typeof this._get === 'function')
     return this._get(key, options, callback)
 
   process.nextTick(function () { callback(new Error('NotFound')) })
@@ -67,10 +67,10 @@ AbstractLevelDOWN.prototype.get = function (key, options, callback) {
 AbstractLevelDOWN.prototype.put = function (key, value, options, callback) {
   var err
 
-  if (typeof options == 'function')
+  if (typeof options === 'function')
     callback = options
 
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('put() requires a callback argument')
 
   if (err = this._checkKey(key, 'key', this._isBuffer))
@@ -84,10 +84,10 @@ AbstractLevelDOWN.prototype.put = function (key, value, options, callback) {
   if (value != null && !this._isBuffer(value) && !process.browser)
     value = String(value)
 
-  if (typeof options != 'object')
+  if (typeof options !== 'object')
     options = {}
 
-  if (typeof this._put == 'function')
+  if (typeof this._put === 'function')
     return this._put(key, value, options, callback)
 
   process.nextTick(callback)
@@ -96,10 +96,10 @@ AbstractLevelDOWN.prototype.put = function (key, value, options, callback) {
 AbstractLevelDOWN.prototype.del = function (key, options, callback) {
   var err
 
-  if (typeof options == 'function')
+  if (typeof options === 'function')
     callback = options
 
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('del() requires a callback argument')
 
   if (err = this._checkKey(key, 'key', this._isBuffer))
@@ -108,10 +108,10 @@ AbstractLevelDOWN.prototype.del = function (key, options, callback) {
   if (!this._isBuffer(key))
     key = String(key)
 
-  if (typeof options != 'object')
+  if (typeof options !== 'object')
     options = {}
 
-  if (typeof this._del == 'function')
+  if (typeof this._del === 'function')
     return this._del(key, options, callback)
 
   process.nextTick(callback)
@@ -121,19 +121,19 @@ AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
   if (!arguments.length)
     return this._chainedBatch()
 
-  if (typeof options == 'function')
+  if (typeof options === 'function')
     callback = options
 
-  if (typeof array == 'function')
+  if (typeof array === 'function')
     callback = array
 
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('batch(array) requires a callback argument')
 
   if (!Array.isArray(array))
     return callback(new Error('batch(array) requires an array argument'))
 
-  if (!options || typeof options != 'object')
+  if (!options || typeof options !== 'object')
     options = {}
 
   var i = 0
@@ -143,7 +143,7 @@ AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
 
   for (; i < l; i++) {
     e = array[i]
-    if (typeof e != 'object')
+    if (typeof e !== 'object')
       continue
 
     if (err = this._checkKey(e.type, 'type', this._isBuffer))
@@ -153,7 +153,7 @@ AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
       return callback(err)
   }
 
-  if (typeof this._batch == 'function')
+  if (typeof this._batch === 'function')
     return this._batch(array, options, callback)
 
   process.nextTick(callback)
@@ -161,14 +161,15 @@ AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
 
 //TODO: remove from here, not a necessary primitive
 AbstractLevelDOWN.prototype.approximateSize = function (start, end, callback) {
-  if (   start == null
-      || end == null
-      || typeof start == 'function'
-      || typeof end == 'function') {
+  console.log(start, end, callback)
+  if (   !start
+      || !end
+      || typeof start === 'function'
+      || typeof end === 'function') {
     throw new Error('approximateSize() requires valid `start`, `end` and `callback` arguments')
   }
 
-  if (typeof callback != 'function')
+  if (typeof callback !== 'function')
     throw new Error('approximateSize() requires a callback argument')
 
   if (!this._isBuffer(start))
@@ -177,7 +178,7 @@ AbstractLevelDOWN.prototype.approximateSize = function (start, end, callback) {
   if (!this._isBuffer(end))
     end = String(end)
 
-  if (typeof this._approximateSize == 'function')
+  if (typeof this._approximateSize === 'function')
     return this._approximateSize(start, end, callback)
 
   process.nextTick(function () {
@@ -207,12 +208,12 @@ AbstractLevelDOWN.prototype._setupIteratorOptions = function (options) {
 }
 
 AbstractLevelDOWN.prototype.iterator = function (options) {
-  if (typeof options != 'object')
+  if (typeof options !== 'object')
     options = {}
 
   options = this._setupIteratorOptions(options)
 
-  if (typeof this._iterator == 'function')
+  if (typeof this._iterator === 'function')
     return this._iterator(options)
 
   return new AbstractIterator(this)

--- a/abstract/batch-test.js
+++ b/abstract/batch-test.js
@@ -104,7 +104,7 @@ module.exports.batch = function (test) {
         if (isTypedArray(value)) {
           result = String.fromCharCode.apply(null, new Uint16Array(value))
         } else {
-          t.ok(typeof Buffer != 'undefined' && value instanceof Buffer)
+          t.ok(typeof Buffer !== 'undefined' && value instanceof Buffer)
           result = value.toString()
         }
         t.equal(result, 'bar')
@@ -124,7 +124,7 @@ module.exports.batch = function (test) {
 
       var r = 0
         , done = function () {
-            if (++r == 3)
+            if (++r === 3)
               t.end()
           }
 
@@ -134,7 +134,7 @@ module.exports.batch = function (test) {
         if (isTypedArray(value)) {
           result = String.fromCharCode.apply(null, new Uint16Array(value))
         } else {
-          t.ok(typeof Buffer != 'undefined' && value instanceof Buffer)
+          t.ok(typeof Buffer !== 'undefined' && value instanceof Buffer)
           result = value.toString()
         }
         t.equal(result, 'bar1')
@@ -143,7 +143,7 @@ module.exports.batch = function (test) {
 
       db.get('foobatch2', function (err, value) {
         t.ok(err, 'entry not found')
-        t.ok(typeof value == 'undefined', 'value is undefined')
+        t.ok(typeof value === 'undefined', 'value is undefined')
         t.ok(verifyNotFoundError(err), 'NotFound error')
         done()
       })
@@ -154,7 +154,7 @@ module.exports.batch = function (test) {
         if (isTypedArray(value)) {
           result = String.fromCharCode.apply(null, new Uint16Array(value))
         } else {
-          t.ok(typeof Buffer != 'undefined' && value instanceof Buffer)
+          t.ok(typeof Buffer !== 'undefined' && value instanceof Buffer)
           result = value.toString()
         }
         t.equal(result, 'bar3')

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -47,7 +47,7 @@ module.exports.del = function (test) {
         t.notOk(err, 'no error')
         db.get('foo', function (err) {
           t.ok(err, 'entry propertly deleted')
-          t.ok(typeof value == 'undefined', 'value is undefined')
+          t.ok(typeof value === 'undefined', 'value is undefined')
           t.ok(verifyNotFoundError(err), 'NotFound error')
           t.end()
         })

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -51,7 +51,7 @@ module.exports.get = function (test) {
         if (isTypedArray(value)) {
           result = String.fromCharCode.apply(null, new Uint16Array(value))
         } else {
-          t.ok(typeof Buffer != 'undefined' && value instanceof Buffer)
+          t.ok(typeof Buffer !== 'undefined' && value instanceof Buffer)
           result = value.toString()
         }
 
@@ -65,7 +65,7 @@ module.exports.get = function (test) {
           if (isTypedArray(value)) {
             result = String.fromCharCode.apply(null, new Uint16Array(value))
           } else {
-            t.ok(typeof Buffer != 'undefined' && value instanceof Buffer)
+            t.ok(typeof Buffer !== 'undefined' && value instanceof Buffer)
             result = value.toString()
           }
 
@@ -87,7 +87,7 @@ module.exports.get = function (test) {
       t.notOk(err, 'should not error')
       var r = 0
         , done = function () {
-            if (++r == 20)
+            if (++r === 20)
               t.end()
           }
         , i = 0
@@ -104,7 +104,7 @@ module.exports.get = function (test) {
         db.get('not found', function(err, value) {
           t.ok(err, 'should error')
           t.ok(verifyNotFoundError(err), 'should have correct error message')
-          t.ok(typeof value == 'undefined', 'value is undefined')
+          t.ok(typeof value === 'undefined', 'value is undefined')
           done()
         })
     })

--- a/abstract/put-get-del-test.js
+++ b/abstract/put-get-del-test.js
@@ -38,7 +38,7 @@ function makePutErrorTest (type, key, value, expectedError) {
 }
 
 function makePutGetDelSuccessfulTest (type, key, value, expectedResult) {
-  var hasExpectedResult = arguments.length == 4
+  var hasExpectedResult = arguments.length === 4
   test('test put()/get()/del() with ' + type, function (t) {
     db.put(key, value, function (err) {
       t.error(err)
@@ -60,7 +60,7 @@ function makePutGetDelSuccessfulTest (type, key, value, expectedResult) {
           db.get(key, function (err,  value) {
             t.ok(err, 'entry propertly deleted')
             t.ok(verifyNotFoundError(err), 'should have correct error message')
-            t.ok(typeof value == 'undefined', 'value is undefined')
+            t.ok(typeof value === 'undefined', 'value is undefined')
             t.end()
           })
         })

--- a/abstract/util.js
+++ b/abstract/util.js
@@ -5,6 +5,6 @@ module.exports.verifyNotFoundError = function verifyNotFoundError (err) {
 }
 
 module.exports.isTypedArray = function isTypedArray (value) {
-  return (typeof ArrayBuffer != 'undefined' && value instanceof ArrayBuffer)
-      || (typeof Uint8Array != 'undefined' && value instanceof Uint8Array)
+  return (typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer)
+      || (typeof Uint8Array !== 'undefined' && value instanceof Uint8Array)
 }

--- a/testCommon.js
+++ b/testCommon.js
@@ -30,7 +30,7 @@ var dbidx = 0
 
         list.forEach(function (f) {
           rimraf(path.join(__dirname, f), function (err) {
-            if (++ret == list.length)
+            if (++ret === list.length)
               callback()
           })
         })


### PR DESCRIPTION
Change all uses of `==` and `!=` to `===` and `!==`.

Previously there where a mixed use of both the strict and the loose type of operators in the source code.
