### PR TITLE
Add default options to open, get, put, del and batch

### DIFF
--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -26,12 +26,6 @@ AbstractLevelDOWN.prototype.open = function (options, callback) {
 
   options.createIfMissing = options.createIfMissing != false
   options.errorIfExists = !!options.errorIfExists
-  options.compression = options.compression != false
-  options.cacheSize = 'cacheSize' in options ? options.cacheSize : 8*1024*1024
-  options.writeBufferSize = 'writeBufferSize' in options ? options.writeBufferSize : 4*1024*1024
-  options.blockSize = 'blockSize' in options ? options.blockSize : 4096
-  options.maxOpenFiles = 'maxOpenFiles' in options ? options.maxOpenFiles : 1000
-  options.blockRestartInterval = 'blockRestartInterval' in options ? options.blockRestartInterval : 16
 
   if (typeof this._open == 'function')
     return this._open(options, callback)
@@ -67,7 +61,6 @@ AbstractLevelDOWN.prototype.get = function (key, options, callback) {
   if (typeof options != 'object')
     options = {}
 
-  options.fillCache = options.fillCache != false
   options.asBuffer = options.asBuffer != false
 
   if (typeof this._get == 'function')
@@ -99,8 +92,6 @@ AbstractLevelDOWN.prototype.put = function (key, value, options, callback) {
   if (typeof options != 'object')
     options = {}
 
-  options.sync = !!options.sync
-
   if (typeof this._put == 'function')
     return this._put(key, value, options, callback)
 
@@ -124,8 +115,6 @@ AbstractLevelDOWN.prototype.del = function (key, options, callback) {
 
   if (typeof options != 'object')
     options = {}
-
-  options.sync = !!options.sync
 
   if (typeof this._del == 'function')
     return this._del(key, options, callback)
@@ -168,8 +157,6 @@ AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
     if (err = this._checkKey(e.key, 'key', this._isBuffer))
       return callback(err)
   }
-
-  options.sync = !!options.sync
 
   if (typeof this._batch == 'function')
     return this._batch(array, options, callback)
@@ -217,7 +204,6 @@ AbstractLevelDOWN.prototype._setupIteratorOptions = function (options) {
   options.keys = options.keys != false
   options.values = options.values != false
   options.limit = 'limit' in options ? options.limit : -1
-  options.fillCache = !!options.fillCache
   options.keyAsBuffer = options.keyAsBuffer != false
   options.valueAsBuffer = options.valueAsBuffer != false
 

--- a/test.js
+++ b/test.js
@@ -64,16 +64,7 @@ tap.test('test core extensibility', function (t) {
 tap.test('test open() extensibility', function (t) {
   var spy = sinon.spy()
     , expectedCb = function () {}
-    , expectedOptions = {
-        createIfMissing: true,
-        errorIfExists: false,
-        compression: true,
-        cacheSize: 8*1024*1024,
-        writeBufferSize: 4*1024*1024,
-        blockSize: 4096,
-        maxOpenFiles: 1000,
-        blockRestartInterval: 16
-      }
+    , expectedOptions = { createIfMissing: true, errorIfExists: false }
     , test
 
   function Test (location) {
@@ -131,7 +122,7 @@ tap.test('test close() extensibility', function (t) {
 tap.test('test get() extensibility', function (t) {
   var spy = sinon.spy()
     , expectedCb = function () {}
-    , expectedOptions = { fillCache: true, asBuffer: true }
+    , expectedOptions = { asBuffer: true }
     , expectedKey = 'a key'
     , test
 
@@ -169,7 +160,7 @@ tap.test('test get() extensibility', function (t) {
 tap.test('test del() extensibility', function (t) {
   var spy = sinon.spy()
     , expectedCb = function () {}
-    , expectedOptions = { sync: false }
+    , expectedOptions = { options: 1 }
     , expectedKey = 'a key'
     , test
 
@@ -188,12 +179,10 @@ tap.test('test del() extensibility', function (t) {
   t.equal(spy.getCall(0).thisValue, test, '`this` on _del() was correct')
   t.equal(spy.getCall(0).args.length, 3, 'got three arguments')
   t.equal(spy.getCall(0).args[0], expectedKey, 'got expected key argument')
-  t.deepEqual(spy.getCall(0).args[1], expectedOptions, 'got default options argument')
+  t.deepEqual(spy.getCall(0).args[1], {}, 'got blank options argument')
   t.equal(spy.getCall(0).args[2], expectedCb, 'got expected cb argument')
 
-  test.del(expectedKey, { options: 1 }, expectedCb)
-
-  expectedOptions.options = 1
+  test.del(expectedKey, expectedOptions, expectedCb)
 
   t.equal(spy.callCount, 2, 'got _del() call')
   t.equal(spy.getCall(1).thisValue, test, '`this` on _del() was correct')
@@ -207,7 +196,7 @@ tap.test('test del() extensibility', function (t) {
 tap.test('test put() extensibility', function (t) {
   var spy = sinon.spy()
     , expectedCb = function () {}
-    , expectedOptions = { sync: false }
+    , expectedOptions = { options: 1 }
     , expectedKey = 'a key'
     , expectedValue = 'a value'
     , test
@@ -228,12 +217,10 @@ tap.test('test put() extensibility', function (t) {
   t.equal(spy.getCall(0).args.length, 4, 'got four arguments')
   t.equal(spy.getCall(0).args[0], expectedKey, 'got expected key argument')
   t.equal(spy.getCall(0).args[1], expectedValue, 'got expected value argument')
-  t.deepEqual(spy.getCall(0).args[2], expectedOptions, 'got blank options argument')
+  t.deepEqual(spy.getCall(0).args[2], {}, 'got blank options argument')
   t.equal(spy.getCall(0).args[3], expectedCb, 'got expected cb argument')
 
-  test.put(expectedKey, expectedValue, { options: 1 }, expectedCb)
-
-  expectedOptions.options = 1
+  test.put(expectedKey, expectedValue, expectedOptions, expectedCb)
 
   t.equal(spy.callCount, 2, 'got _put() call')
   t.equal(spy.getCall(1).thisValue, test, '`this` on _put() was correct')
@@ -275,7 +262,7 @@ tap.test('test approximateSize() extensibility', function (t) {
 tap.test('test batch() extensibility', function (t) {
   var spy = sinon.spy()
     , expectedCb = function () {}
-    , expectedOptions = { sync: false }
+    , expectedOptions = { options: 1 }
     , expectedArray = [ 1, 2 ]
     , test
 
@@ -295,12 +282,10 @@ tap.test('test batch() extensibility', function (t) {
   t.equal(spy.getCall(0).thisValue, test, '`this` on _batch() was correct')
   t.equal(spy.getCall(0).args.length, 3, 'got three arguments')
   t.equal(spy.getCall(0).args[0], expectedArray, 'got expected array argument')
-  t.deepEqual(spy.getCall(0).args[1], expectedOptions, 'got default options argument')
+  t.deepEqual(spy.getCall(0).args[1], {}, 'got expected options argument')
   t.equal(spy.getCall(0).args[2], expectedCb, 'got expected callback argument')
 
-  test.batch(expectedArray, { options: 1 }, expectedCb)
-
-  expectedOptions.options = 1
+  test.batch(expectedArray, expectedOptions, expectedCb)
 
   t.equal(spy.callCount, 2, 'got _batch() call')
   t.equal(spy.getCall(1).thisValue, test, '`this` on _batch() was correct')
@@ -502,7 +487,7 @@ tap.test('test clear() extensibility', function (t) {
 
 tap.test('test iterator() extensibility', function (t) {
   var spy = sinon.spy()
-    , expectedOptions = { options: 1, reverse: false, keys: true, values: true, limit: -1, fillCache: false, keyAsBuffer: true, valueAsBuffer: true }
+    , expectedOptions = { options: 1, reverse: false, keys: true, values: true, limit: -1, keyAsBuffer: true, valueAsBuffer: true }
     , test
 
   function Test (location) {


### PR DESCRIPTION
This is a proposal to add default options in all locations where those can occur: `_open`, `_get`, `_put`, `_del` and `_batch` (the `_iterator` function had default options-handling added by PR #32)

Previously an empty object was passed as the options argument which let the implementers of abstract-leveldown deal with the default options on their own. By elevating this to an abstract-leveldown responsibility, we can ensure this is handled evenly across all DOWN's.

All default options listed for leveldown have been added:
- [Default options for `leveldown#open([options, ]callback)`](https://github.com/rvagg/node-leveldown#options)
- [Default options for `leveldown#put(key, value[, options], callback)`](https://github.com/rvagg/node-leveldown#options-1)
- [Default options for `leveldown#get(key[, options], callback`)](https://github.com/rvagg/node-leveldown#options-2)
- [Default options for `leveldown#del(key[, options], callback)`](https://github.com/rvagg/node-leveldown#options-3)
- [Default options for `leveldown#batch(operations[, options], callback)`](https://github.com/rvagg/node-leveldown#options-4)
