### PR TITLE
Fix asBuffer Array test

### DIFF
--- a/abstract/put-get-del-test.js
+++ b/abstract/put-get-del-test.js
@@ -4,7 +4,8 @@
 var db
   , testBuffer
   , test
-  , verifyNotFoundError = require('./util').verifyNotFoundError
+  , util = require('./util')
+  , verifyNotFoundError = util.verifyNotFoundError
 
 function makeGetDelErrorTests (type, key, expectedError) {
   test('test get() with ' + type + ' causes error', function (t) {
@@ -51,8 +52,12 @@ function makePutGetDelSuccessfulTest (type, key, value, expectedResult) {
         } else {
           if (result != null)
             result = _value.toString()
-          if (value != null)
-            value = value.toString()
+          if (value != null) {
+            if (util.isArray(value))
+              value = new Buffer(value).toString()
+            else
+              value = value.toString()
+          }
           t.equals(result, value)
         }
         db.del(key, function (err) {

--- a/abstract/util.js
+++ b/abstract/util.js
@@ -8,3 +8,7 @@ module.exports.isTypedArray = function isTypedArray (value) {
   return (typeof ArrayBuffer != 'undefined' && value instanceof ArrayBuffer)
       || (typeof Uint8Array != 'undefined' && value instanceof Uint8Array)
 }
+
+module.exports.isArray = function (arr) {
+  return Array.isArray ? Array.isArray(arr) : (arr && arr.push && arr.length);
+}


### PR DESCRIPTION
This test doesn't appear correct to me.

Let's say I put an array of integers as a value:

``` js
var db = require('level')('mydb')
db.put('foo', [1, 2, 3, 4])
```

If you call

``` js
db.get('foo', {valueEncoding: 'binary'}, console.log)
```

Which of these two buffers would you expect to get back?

```
new Buffer([1, 2, 3, 4])
new Buffer("1,2,3,4")
```

I would tend to expect the first buffer, but instead I get back the second one.
