### PR TITLE
Use `setImmediate`.

### DIFF
--- a/testCommon.js
+++ b/testCommon.js
@@ -59,7 +59,7 @@ var dbidx = 0
                 })
               }
               data.push({ key: key, value: value })
-              setImmediate(next)
+              setTimeout(next, 0)
             })
           }
       next()


### PR DESCRIPTION
In pure-JavaScript implementations that aggressively cache records certain test will blow the stack if `process.nextTick` is used. The warning issued suggests the use of `setImmediate`.
