### PR TITLE
Implement `collectEntries` as trampoline.

### DIFF
--- a/testCommon.js
+++ b/testCommon.js
@@ -51,6 +51,11 @@ var dbidx = 0
   , collectEntries = function (iterator, callback) {
       var data = []
         , next = function () {
+            var f = _next()
+            while (f) f = f()
+          }
+        , _next = function () {
+            var state = 0
             iterator.next(function (err, key, value) {
               if (err) return callback(err)
               if (!arguments.length) {
@@ -59,9 +64,19 @@ var dbidx = 0
                 })
               }
               data.push({ key: key, value: value })
-              process.nextTick(next)
+              if (state == 1) {
+                next()
+              } else {
+                state = 1
+              }
             })
+            if (state == 1) {
+              return _next
+            } else {
+              state = 1
+            }
           }
+
       next()
     }
 


### PR DESCRIPTION
In pure-JavaScript implementations that aggressively cache records certain test will blow the stack if `process.nextTick` is used. The warning issued suggests the use of `setImmediate` however, not all platforms may support `setImmediate`.

This implementation of `collectEntries` uses a trampoline so that invocations of `iterator.next` that do not result in an asynchronous call will not increase the depth of the stack. This eliminates recursion and prevents stack overflow.
