### PR TITLE
Don't fail if no value is returned by _get

### DIFF
--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -52,7 +52,11 @@ module.exports.get = function (test) {
           result = String.fromCharCode.apply(null, new Uint16Array(value))
         } else {
           t.ok(typeof Buffer != 'undefined' && value instanceof Buffer)
-          result = value.toString()
+          try {
+            result = value.toString()
+          } catch (e) {
+            t.error(e, 'should not throw when converting value to a string')
+          }
         }
 
         t.equal(result, 'bar')
@@ -66,7 +70,11 @@ module.exports.get = function (test) {
             result = String.fromCharCode.apply(null, new Uint16Array(value))
           } else {
             t.ok(typeof Buffer != 'undefined' && value instanceof Buffer)
-            result = value.toString()
+            try {
+              result = value.toString()
+            } catch (e) {
+              t.error(e, 'should not throw when converting value to a string')
+            }
           }
 
           t.equal(result, 'bar')


### PR DESCRIPTION
In case something isn't right with the `_get` method, we should avoid throwing an error when trying to call `.toString()` on `undefined`.

You could argue that the absence of a proper `value` is in it self an error, which is true, but when tape throws an error like this it masks any assertion errors that might have have occurred before this error was thrown. This makes it extremely difficult to debug why the error occurred in the first place as there might have been a meaningful assertion error just a couple of lines before that would have told you what was wrong.
