### PR TITLE
Let the API free fly(+ sync execution ability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,85 @@ You add functionality by implementing the underscore versions of the operations.
 
 Additionally, all methods provide argument checking and sensible defaults for optional arguments. All bad-argument errors are compatible with LevelDOWN (they pass the LevelDOWN method arguments tests). For example, if you call `.open()` without a callback argument you'll get an `Error('open() requires a callback argument')`. Where optional arguments are involved, your underscore methods will receive sensible defaults. A `.get(key, callback)` will pass through to a `._get(key, options, callback)` where the `options` argument is an empty object.
 
+
+## Changes
+
+Add the sync methods support now. You can implement the sync methods only.
+The async methods will be simulated via these sync methods. if you wanna
+support the async only, just do not implement these sync methods.
+but if you wanna support the sync only, you should override the async methods to disable it.
+
 ## Example
 
 A simplistic in-memory LevelDOWN replacement
+
+use sync methods:
+
+
+```js
+var util = require('util')
+  , AbstractLevelDOWN = require('./').AbstractLevelDOWN
+
+// constructor, passes through the 'location' argument to the AbstractLevelDOWN constructor
+function FakeLevelDOWN (location) {
+  AbstractLevelDOWN.call(this, location)
+}
+
+// our new prototype inherits from AbstractLevelDOWN
+util.inherits(FakeLevelDOWN, AbstractLevelDOWN)
+
+// implement some methods
+
+FakeLevelDOWN.prototype._openSync = function (options) {
+  this._store = {}
+  return true
+}
+
+FakeLevelDOWN.prototype._putSync = function (key, value, options) {
+  key = '_' + key // safety, to avoid key='__proto__'-type skullduggery 
+  this._store[key] = value
+  return true
+}
+
+FakeLevelDOWN.prototype._get = function (key, options) {
+  var value = this._store['_' + key]
+  if (value === undefined) {
+    // 'NotFound' error, consistent with LevelDOWN API
+    throw new Error('NotFound')
+  }
+  return value
+}
+
+FakeLevelDOWN.prototype._del = function (key, options) {
+  delete this._store['_' + key]
+  return true
+}
+
+// now use it in LevelUP
+
+var levelup = require('levelup')
+
+var db = levelup('/who/cares/', {
+  // the 'db' option replaces LevelDOWN
+  db: function (location) { return new FakeLevelDOWN(location) }
+})
+
+//async:
+db.put('foo', 'bar', function (err) {
+  if (err) throw err
+  db.get('foo', function (err, value) {
+    if (err) throw err
+    console.log('Got foo =', value)
+  })
+})
+
+//sync:
+db.put('foo', 'bar')
+console.log(db.get('foo'))
+```
+
+use async methods(no sync supports now):
+
 
 ```js
 var util = require('util')

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -30,7 +30,7 @@ AbstractLevelDOWN.prototype.putSync = function (key, value, options) {
   throw new Error("NotImplementation")
 }
 
-AbstractLevelDOWN.prototype.delSync = function (key, flushSync) {
+AbstractLevelDOWN.prototype.delSync = function (key, options) {
   if (this._delSync) {
     var result = this._delSync(key, options)
     return result
@@ -74,10 +74,11 @@ AbstractLevelDOWN.prototype.closeSync = function () {
 //the async methods simulated by sync methods:
 //the derived class can override these methods to implement the real async methods for better performance.
 AbstractLevelDOWN.prototype._open = function (options, callback) {
+  var that = this
   if (this._openSync) setImmediate(function() {
     var result
     try {
-      result = this._openSync(options)
+      result = that._openSync(options)
     } catch (err) {
       callback(err)
       return
@@ -87,10 +88,11 @@ AbstractLevelDOWN.prototype._open = function (options, callback) {
   setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._close = function (callback) {
+  var that = this
   if (this._closeSync) setImmediate(function() {
     var result
     try {
-      result = this._closeSync()
+      result = that._closeSync()
     } catch (err) {
       callback(err)
       return
@@ -100,10 +102,11 @@ AbstractLevelDOWN.prototype._close = function (callback) {
   setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._get = function (key, options, callback) {
+  var that = this
   if (this._getSync) setImmediate(function() {
     var result
     try {
-      result = this._getSync(key, options)
+      result = that._getSync(key, options)
     } catch (err) {
       callback(err)
       return
@@ -113,10 +116,11 @@ AbstractLevelDOWN.prototype._get = function (key, options, callback) {
   setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._put = function (key, value, options, callback) {
+  var that = this
   if (this._putSync) setImmediate(function() {
     var result
     try {
-      result = this._putSync(key, value, options)
+      result = that._putSync(key, value, options)
     } catch (err) {
       callback(err)
       return
@@ -126,10 +130,11 @@ AbstractLevelDOWN.prototype._put = function (key, value, options, callback) {
   setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._del = function (key, options, callback) {
+  var that = this
   if (this._delSync) setImmediate(function() {
     var result
     try {
-      result = this._delSync(key, options)
+      result = that._delSync(key, options)
     } catch (err) {
       callback(err)
       return
@@ -139,10 +144,11 @@ AbstractLevelDOWN.prototype._del = function (key, options, callback) {
   setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._batch = function (array, options, callback) {
+  var that = this
   if (this._batchSync) setImmediate(function() {
     var result
     try {
-      result = this._batchSync(array, options)
+      result = that._batchSync(array, options)
     } catch (err) {
       callback(err)
       return
@@ -153,10 +159,11 @@ AbstractLevelDOWN.prototype._batch = function (array, options, callback) {
 }
 //TODO: remove from here, not a necessary primitive
 AbstractLevelDOWN.prototype._approximateSize = function (start, end, callback) {
+  var that = this
   if (this._approximateSizeSync) setImmediate(function() {
     var result
     try {
-      result = this._approximateSizeSync(start, end, options)
+      result = that._approximateSizeSync(start, end, options)
     } catch (err) {
       callback(err)
       return
@@ -168,10 +175,11 @@ AbstractLevelDOWN.prototype._approximateSize = function (start, end, callback) {
 //slower impl:
 /*
 AbstractLevelDOWN.prototype._exec = function (fn, args, callback) {
+  var that = this
   if (fn) setImmediate(function() {
     var result
     try {
-      result = fn.apply(this, args)
+      result = fn.apply(that, args)
     } catch (err) {
       callback(err)
       return

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -85,7 +85,8 @@ AbstractLevelDOWN.prototype._open = function (options, callback) {
     }
     callback(null, result)
   })
-  setImmediate(callback)
+  else
+    setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._close = function (callback) {
   var that = this
@@ -99,7 +100,8 @@ AbstractLevelDOWN.prototype._close = function (callback) {
     }
     callback(null, result)
   })
-  setImmediate(callback)
+  else
+    setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._get = function (key, options, callback) {
   var that = this
@@ -113,7 +115,8 @@ AbstractLevelDOWN.prototype._get = function (key, options, callback) {
     }
     callback(null, result)
   })
-  setImmediate(callback)
+  else
+    setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._put = function (key, value, options, callback) {
   var that = this
@@ -127,7 +130,8 @@ AbstractLevelDOWN.prototype._put = function (key, value, options, callback) {
     }
     callback(null, result)
   })
-  setImmediate(callback)
+  else
+    setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._del = function (key, options, callback) {
   var that = this
@@ -141,7 +145,8 @@ AbstractLevelDOWN.prototype._del = function (key, options, callback) {
     }
     callback(null, result)
   })
-  setImmediate(callback)
+  else
+    setImmediate(callback)
 }
 AbstractLevelDOWN.prototype._batch = function (array, options, callback) {
   var that = this
@@ -155,7 +160,8 @@ AbstractLevelDOWN.prototype._batch = function (array, options, callback) {
     }
     callback(null, result)
   })
-  setImmediate(callback)
+  else
+    setImmediate(callback)
 }
 //TODO: remove from here, not a necessary primitive
 AbstractLevelDOWN.prototype._approximateSize = function (start, end, callback) {
@@ -170,7 +176,8 @@ AbstractLevelDOWN.prototype._approximateSize = function (start, end, callback) {
     }
     callback(null, result)
   })
-  setImmediate(callback)
+  else
+    setImmediate(callback)
 }
 //slower impl:
 /*

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -170,7 +170,7 @@ AbstractLevelDOWN.prototype._approximateSize = function (start, end, callback) {
   if (this._approximateSizeSync) setImmediate(function() {
     var result
     try {
-      result = that._approximateSizeSync(start, end, options)
+      result = that._approximateSizeSync(start, end)
     } catch (err) {
       callback(err)
       return

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -2,6 +2,7 @@
 var xtend                = require('xtend')
   , AbstractIterator     = require('./abstract-iterator')
   , AbstractChainedBatch = require('./abstract-chained-batch')
+  , setImmediate         = global.setImmediate || process.nextTick
 
 function AbstractLevelDOWN (location) {
   if (!arguments.length || location === undefined)

--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -85,11 +85,8 @@ module.exports.approximateSize = function (test) {
                                  // original would be ~100000
                   , 'size reports a reasonable amount (' + size + ')'
                 )
+                t.end()
 
-                db.close(function (err) {
-                  t.error(err)
-                  t.end()
-                })
               })
             })
           })
@@ -117,7 +114,7 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.approximateSize(test)
-  if (leveldown._approximateSizeSync) {
+  if (leveldown.prototype._approximateSizeSync) {
     module.exports.sync(test)
     module.exports.approximateSize(test)
   }

--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -12,7 +12,7 @@ module.exports.args = function (test) {
   test('test argument-less approximateSize() throws', function (t) {
     t.throws(
         db.approximateSize.bind(db)
-      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback` arguments' }
+      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback`(for async) arguments' }
       , 'no-arg approximateSize() throws'
     )
     t.end()
@@ -21,17 +21,8 @@ module.exports.args = function (test) {
   test('test callback-less, 1-arg, approximateSize() throws', function (t) {
     t.throws(
         db.approximateSize.bind(db, 'foo')
-      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback` arguments' }
+      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback`(for async) arguments' }
       , 'callback-less, 1-arg approximateSize() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 2-arg, approximateSize() throws', function (t) {
-    t.throws(
-        db.approximateSize.bind(db, 'foo', 'bar')
-      , { name: 'Error', message: 'approximateSize() requires a callback argument' }
-      , 'callback-less, 2-arg approximateSize() throws'
     )
     t.end()
   })
@@ -39,7 +30,7 @@ module.exports.args = function (test) {
   test('test callback-less, 3-arg, approximateSize() throws', function (t) {
     t.throws(
         db.approximateSize.bind(db, function () {})
-      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback` arguments' }
+      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback`(for async) arguments' }
       , 'callback-only approximateSize() throws'
     )
     t.end()
@@ -48,7 +39,7 @@ module.exports.args = function (test) {
   test('test callback-only approximateSize() throws', function (t) {
     t.throws(
         db.approximateSize.bind(db, function () {})
-      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback` arguments' }
+      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback`(for async) arguments' }
       , 'callback-only approximateSize() throws'
     )
     t.end()
@@ -57,13 +48,19 @@ module.exports.args = function (test) {
   test('test 1-arg + callback approximateSize() throws', function (t) {
     t.throws(
         db.approximateSize.bind(db, 'foo', function () {})
-      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback` arguments' }
+      , { name: 'Error', message: 'approximateSize() requires valid `start`, `end` and `callback`(for async) arguments' }
       , '1-arg + callback approximateSize() throws'
     )
     t.end()
   })
 }
 
+module.exports.approximateSizeSync = function (test) {
+  if (db._approximateSizeSync) {
+    delete db.prototype._approximateSize
+    module.exports.approximateSize(test)
+  }
+}
 module.exports.approximateSize = function (test) {
   test('test approximateSize()', function (t) {
     var data = Array.apply(null, Array(10000)).map(function () {
@@ -117,5 +114,6 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.approximateSize(test)
+  module.exports.approximateSizeSync(test)
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -55,12 +55,6 @@ module.exports.args = function (test) {
   })
 }
 
-module.exports.approximateSizeSync = function (test) {
-  if (db._approximateSizeSync) {
-    delete db.prototype._approximateSize
-    module.exports.approximateSize(test)
-  }
-}
 module.exports.approximateSize = function (test) {
   test('test approximateSize()', function (t) {
     var data = Array.apply(null, Array(10000)).map(function () {
@@ -104,6 +98,15 @@ module.exports.approximateSize = function (test) {
   })
 }
 
+module.exports.sync = function (test) {
+  test('sync', function (t) {
+    if (db._approximateSizeSync) {
+      delete db.__proto__._approximateSize
+    }
+    t.end()
+  })
+}
+
 module.exports.tearDown = function (test, testCommon) {
   test('tearDown', function (t) {
     db.close(testCommon.tearDown.bind(null, t))
@@ -114,6 +117,9 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.approximateSize(test)
-  module.exports.approximateSizeSync(test)
+  if (leveldown._approximateSizeSync) {
+    module.exports.sync(test)
+    module.exports.approximateSize(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/batch-test.js
+++ b/abstract/batch-test.js
@@ -182,15 +182,22 @@ module.exports.tearDown = function (test, testCommon) {
   })
 }
 
+module.exports.sync = function (test) {
+  test('sync', function (t) {
+    if (db._batchSync) {
+      delete db.__proto__._batch
+    }
+    t.end()
+  })
+}
+
 module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.batch(test)
   module.exports.atomic(test)
-  if (db._batchSync) {
-    delete db.prototype._batch
-    module.exports.batch(test)
-    module.exports.atomic(test)
-  }
+  module.exports.sync(test)
+  module.exports.batch(test)
+  module.exports.atomic(test)
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/batch-test.js
+++ b/abstract/batch-test.js
@@ -196,8 +196,10 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.args(test)
   module.exports.batch(test)
   module.exports.atomic(test)
-  module.exports.sync(test)
-  module.exports.batch(test)
-  module.exports.atomic(test)
+  if (leveldown._batchSync) {
+    module.exports.sync(test)
+    module.exports.batch(test)
+    module.exports.atomic(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/batch-test.js
+++ b/abstract/batch-test.js
@@ -196,7 +196,7 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.args(test)
   module.exports.batch(test)
   module.exports.atomic(test)
-  if (leveldown._batchSync) {
+  if (leveldown.prototype._batchSync) {
     module.exports.sync(test)
     module.exports.batch(test)
     module.exports.atomic(test)

--- a/abstract/batch-test.js
+++ b/abstract/batch-test.js
@@ -11,11 +11,6 @@ module.exports.setUp = function (leveldown, test, testCommon) {
 }
 
 module.exports.args = function (test) {
-  test('test callback-less, 2-arg, batch() throws', function (t) {
-    t.throws(db.batch.bind(db, 'foo', {}), 'callback-less, 2-arg batch() throws')
-    t.end()
-  })
-
   test('test batch() with missing `value`', function (t) {
     db.batch([{ type: 'put', key: 'foo1' }], function (err) {
       t.error(err)
@@ -192,5 +187,10 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.args(test)
   module.exports.batch(test)
   module.exports.atomic(test)
+  if (db._batchSync) {
+    delete db.prototype._batch
+    module.exports.batch(test)
+    module.exports.atomic(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/close-test.js
+++ b/abstract/close-test.js
@@ -4,8 +4,6 @@ module.exports.close = function (leveldown, test, testCommon) {
 
     db.open(function (err) {
       t.error(err)
-      if (db._closeSync)
-        t.ok(db.close(), "close sync should be ok")
       t.throws(
           db.close.bind(db, 'foo')
         , { name: 'Error', message: 'close() requires callback function argument' }

--- a/abstract/close-test.js
+++ b/abstract/close-test.js
@@ -4,14 +4,11 @@ module.exports.close = function (leveldown, test, testCommon) {
 
     db.open(function (err) {
       t.error(err)
-      t.throws(
-          db.close.bind(db)
-        , { name: 'Error', message: 'close() requires a callback argument' }
-        , 'no-arg close() throws'
-      )
+      if (db._closeSync)
+        t.ok(db.close(), "close sync should be ok")
       t.throws(
           db.close.bind(db, 'foo')
-        , { name: 'Error', message: 'close() requires a callback argument' }
+        , { name: 'Error', message: 'close() requires callback function argument' }
         , 'non-callback close() throws'
       )
 

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -11,32 +11,6 @@ module.exports.setUp = function (leveldown, test, testCommon) {
 }
 
 module.exports.args = function (test) {
-  test('test argument-less del() throws', function (t) {
-    t.throws(
-        db.del.bind(db)
-      , { name: 'Error', message: 'del() requires a callback argument' }
-      , 'no-arg del() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 1-arg, del() throws', function (t) {
-    t.throws(
-        db.del.bind(db, 'foo')
-      , { name: 'Error', message: 'del() requires a callback argument' }
-      , 'callback-less, 1-arg del() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 3-arg, del() throws', function (t) {
-    t.throws(
-        db.del.bind(db, 'foo', {})
-      , { name: 'Error', message: 'del() requires a callback argument' }
-      , 'callback-less, 2-arg del() throws'
-    )
-    t.end()
-  })
 }
 
 module.exports.del = function (test) {
@@ -73,5 +47,9 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.del(test)
+  if (db._delSync) {
+    delete db.prototype._del
+    module.exports.del(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -43,13 +43,20 @@ module.exports.tearDown = function (test, testCommon) {
   })
 }
 
+module.exports.sync = function (test) {
+  test('sync', function (t) {
+    if (db._delSync) {
+      delete db.__proto__._del
+    }
+    t.end()
+  })
+}
+
 module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.del(test)
-  if (db._delSync) {
-    delete db.prototype._del
-    module.exports.del(test)
-  }
+  module.exports.sync(test)
+  module.exports.del(test)
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -56,7 +56,7 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.del(test)
-  if (leveldown._delSync) {
+  if (leveldown.prototype._delSync) {
     module.exports.sync(test)
     module.exports.del(test)
   }

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -56,7 +56,9 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.del(test)
-  module.exports.sync(test)
-  module.exports.del(test)
+  if (leveldown._delSync) {
+    module.exports.sync(test)
+    module.exports.del(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -99,13 +99,20 @@ module.exports.tearDown = function (test, testCommon) {
   })
 }
 
+module.exports.sync = function (test) {
+  test('sync', function (t) {
+    if (db._getSync) {
+      delete db.__proto__._get
+    }
+    t.end()
+  })
+}
+
 module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.get(test)
-  if (db._getSync) {
-    delete db.prototype._get
-    module.exports.get(test)
-  }
+  module.exports.sync(test)
+  module.exports.get(test)
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -112,7 +112,9 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.get(test)
-  module.exports.sync(test)
-  module.exports.get(test)
+  if (leveldown._getSync) {
+    module.exports.sync(test)
+    module.exports.get(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -11,32 +11,6 @@ module.exports.setUp = function (leveldown, test, testCommon) {
 }
 
 module.exports.args = function (test) {
-  test('test argument-less get() throws', function (t) {
-    t.throws(
-        db.get.bind(db)
-      , { name: 'Error', message: 'get() requires a callback argument' }
-      , 'no-arg get() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 1-arg, get() throws', function (t) {
-    t.throws(
-        db.get.bind(db, 'foo')
-      , { name: 'Error', message: 'get() requires a callback argument' }
-      , 'callback-less, 1-arg get() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 3-arg, get() throws', function (t) {
-    t.throws(
-        db.get.bind(db, 'foo', {})
-      , { name: 'Error', message: 'get() requires a callback argument' }
-      , 'callback-less, 2-arg get() throws'
-    )
-    t.end()
-  })
 }
 
 module.exports.get = function (test) {
@@ -129,5 +103,9 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.get(test)
+  if (db._getSync) {
+    delete db.prototype._get
+    module.exports.get(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/open-test.js
+++ b/abstract/open-test.js
@@ -89,8 +89,8 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.args(leveldown, test, testCommon)
   module.exports.open(leveldown, test, testCommon)
   module.exports.openAdvanced(leveldown, test, testCommon)
-  if (db._openSync) {
-    delete db.prototype._open
+  if (leveldown._openSync) {
+    delete db.__proto__._open
     module.exports.open(leveldown, test, testCommon)
     module.exports.openAdvanced(leveldown, test, testCommon)
   }

--- a/abstract/open-test.js
+++ b/abstract/open-test.js
@@ -89,8 +89,8 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.args(leveldown, test, testCommon)
   module.exports.open(leveldown, test, testCommon)
   module.exports.openAdvanced(leveldown, test, testCommon)
-  if (leveldown._openSync) {
-    delete db.__proto__._open
+  if (leveldown.prototype._openSync) {
+    delete leveldown.prototype._open
     module.exports.open(leveldown, test, testCommon)
     module.exports.openAdvanced(leveldown, test, testCommon)
   }

--- a/abstract/open-test.js
+++ b/abstract/open-test.js
@@ -3,25 +3,6 @@ module.exports.setUp = function (test, testCommon) {
 }
 
 module.exports.args = function (leveldown, test, testCommon) {
-  test('test database open no-arg throws', function (t) {
-    var db = leveldown(testCommon.location())
-    t.throws(
-        db.open.bind(db)
-      , { name: 'Error', message: 'open() requires a callback argument' }
-      , 'no-arg open() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 1-arg, open() throws', function (t) {
-    var db = leveldown(testCommon.location())
-    t.throws(
-        db.open.bind(db, {})
-      , { name: 'Error', message: 'open() requires a callback argument' }
-      , 'callback-less, 1-arg open() throws'
-    )
-    t.end()
-  })
 }
 
 module.exports.open = function (leveldown, test, testCommon) {
@@ -108,5 +89,10 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.args(leveldown, test, testCommon)
   module.exports.open(leveldown, test, testCommon)
   module.exports.openAdvanced(leveldown, test, testCommon)
+  if (db._openSync) {
+    delete db.prototype._open
+    module.exports.open(leveldown, test, testCommon)
+    module.exports.openAdvanced(leveldown, test, testCommon)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -62,7 +62,9 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.put(test)
-  module.exports.sync(test)
-  module.exports.put(test)
+  if (leveldown._putSync) {
+    module.exports.sync(test)
+    module.exports.put(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -22,7 +22,7 @@ module.exports.put = function (test) {
         var result = value.toString()
         if (isTypedArray(value))
           result = String.fromCharCode.apply(null, new Uint16Array(value))
-        t.equal(result, 'bar')
+        t.equal(result, 'bar', "should be ok")
         t.end()
       })
     })
@@ -49,13 +49,20 @@ module.exports.tearDown = function (test, testCommon) {
   })
 }
 
+module.exports.sync = function (test) {
+  test('sync', function (t) {
+    if (db._putSync) {
+      delete db.__proto__._put
+    }
+    t.end()
+  })
+}
+
 module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.put(test)
-  if (db._putSync) {
-    delete db.prototype._put
-    module.exports.put(test)
-  }
+  module.exports.sync(test)
+  module.exports.put(test)
   module.exports.tearDown(test, testCommon)
 }

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -62,7 +62,7 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.put(test)
-  if (leveldown._putSync) {
+  if (leveldown.prototype._putSync) {
     module.exports.sync(test)
     module.exports.put(test)
   }

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -11,41 +11,6 @@ module.exports.setUp = function (leveldown, test, testCommon) {
 }
 
 module.exports.args = function (test) {
-  test('test argument-less put() throws', function (t) {
-    t.throws(
-        db.put.bind(db)
-      , { name: 'Error', message: 'put() requires a callback argument' }
-      , 'no-arg put() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 1-arg, put() throws', function (t) {
-    t.throws(
-        db.put.bind(db, 'foo')
-      , { name: 'Error', message: 'put() requires a callback argument' }
-      , 'callback-less, 1-arg put() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 2-arg, put() throws', function (t) {
-    t.throws(
-        db.put.bind(db, 'foo', 'bar')
-      , { name: 'Error', message: 'put() requires a callback argument' }
-      , 'callback-less, 2-arg put() throws'
-    )
-    t.end()
-  })
-
-  test('test callback-less, 3-arg, put() throws', function (t) {
-    t.throws(
-        db.put.bind(db, 'foo', 'bar', {})
-      , { name: 'Error', message: 'put() requires a callback argument' }
-      , 'callback-less, 3-arg put() throws'
-    )
-    t.end()
-  })
 }
 
 module.exports.put = function (test) {
@@ -88,5 +53,9 @@ module.exports.all = function (leveldown, test, testCommon) {
   module.exports.setUp(leveldown, test, testCommon)
   module.exports.args(test)
   module.exports.put(test)
+  if (db._putSync) {
+    delete db.prototype._put
+    module.exports.put(test)
+  }
   module.exports.tearDown(test, testCommon)
 }

--- a/test.js
+++ b/test.js
@@ -7,12 +7,6 @@ const tap                  = require('tap')
     , AbstractChainedBatch = require('./').AbstractChainedBatch
 
 
-//let debug more easy.
-global.setImmediate = function(callback) {
-  callback()
-}
-
-
 function factory (location) {
   return new AbstractLevelDOWN(location)
 }

--- a/test.js
+++ b/test.js
@@ -6,6 +6,13 @@ const tap                  = require('tap')
     , AbstractIterator     = require('./').AbstractIterator
     , AbstractChainedBatch = require('./').AbstractChainedBatch
 
+
+//let debug more easy.
+global.setImmediate = function(callback) {
+  callback()
+}
+
+
 function factory (location) {
   return new AbstractLevelDOWN(location)
 }

--- a/testCommon.js
+++ b/testCommon.js
@@ -2,6 +2,11 @@ var path      = require('path')
   , fs        = !process.browser && require('fs')
   , rimraf    = !process.browser && require('rimraf')
 
+//let debug more easy.
+global.setImmediate = function(callback) {
+  callback()
+}
+
 var dbidx = 0
 
   , location = function () {

--- a/testCommon.js
+++ b/testCommon.js
@@ -4,7 +4,8 @@ var path      = require('path')
 
 //let debug more easy.
 global.setImmediate = function(callback) {
-  callback()
+  setTimeout(callback, 0) //for iterator-recursion-test.js
+  //callback() //will raise max stack exceed error!
 }
 
 var dbidx = 0

--- a/testCommon.js
+++ b/testCommon.js
@@ -2,11 +2,11 @@ var path      = require('path')
   , fs        = !process.browser && require('fs')
   , rimraf    = !process.browser && require('rimraf')
 
-//let debug more easy.
+/*//let debug more easy.
 global.setImmediate = function(callback) {
   setTimeout(callback, 0) //for iterator-recursion-test.js
   //callback() //will raise max stack exceed error!
-}
+}//*/
 
 var dbidx = 0
 

--- a/testCommon.js
+++ b/testCommon.js
@@ -4,7 +4,6 @@ var path      = require('path')
 
 /*//let debug more easy.
 global.setImmediate = function(callback) {
-  setTimeout(callback, 0) //for iterator-recursion-test.js
   //callback() //will raise max stack exceed error!
 }//*/
 


### PR DESCRIPTION
release more limited, and make more possible for others. the async is very perfect for slow IO operations, such as file or network.  more and more database use memory to cache data. the get operation is not a slow IO, so sync is better than async here. And maybe some database changes the put etc operations more effective. so
why need to limit the async only? on my leveldb's test(add the sync ability to leveldown), only iteractor.next using callback is better than sync. All others are sync better than async. btw, the asBuffer is performance killer.

``` shell
          put :    27,334 w/s in    439ms
      putSync :    72,289 w/s in    166ms
      putSync :    72,289 w/s in    166ms        (directly)

        batch :   104,347 w/s in    115ms
    batchSync :   151,898 w/s in     79ms
    batchSync :   144,578 w/s in     83ms        (directly)

          get :    30,769 r/s in    390ms        (asBuffer)
          get :    48,780 r/s in    246ms
      getSync :    76,433 r/s in    157ms        (asBuffer)
      getSync :   240,000 r/s in     50ms
      getSync :   235,294 r/s in     51ms        (directly)

     iterator :    79,470 r/s in    151ms        (asBuffer)
     iterator :   127,659 r/s in     94ms
     iterator :   300,000 r/s in     40ms        (directly)
 iteratorSync :   272,727 r/s in     44ms        (directly)
```
- [feature] New Sync API methods supported, and you can implement these sync methods to build your level-database package. if no async methods exists, using the sync methods to simulate the async.
- [feature] the API will be sync if no callback argument.

``` js
var result = open(); //sync call  =openSync
open(function(){}); //async call
```

you only need to implement these sync methods:

``` js
_openSync, _getSync, _putSync, _delSync, _batchSync, _closeSync
```

of cause, u can implement these async methods too, suggestion for slow IO functions:

``` js
_put, _del, _batch, _close, _next
```
