### PR TITLE
add sync put tests

### DIFF
--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -78,6 +78,28 @@ module.exports.put = function (test) {
 
 }
 
+module.exports.sync = function (test) {
+  test('sync put', function (t) {
+    db.put('foo', 'bar', { sync: true }, function (err) {
+      t.error(err)
+      db.get('foo', function (err, value) {
+        t.error(err)
+        t.equal(value.toString(), 'bar')
+        t.end()
+      })
+    })
+  })
+  test('sync put just before close', function (t) {
+    t.plan(2)
+    db.put('foo', 'bar', { sync: true }, function (err) {
+      t.error(err)
+    })
+    db.close(function (err) {
+      t.error(err)
+    })
+  })
+}
+
 module.exports.tearDown = function (test, testCommon) {
   test('tearDown', function (t) {
     db.close(testCommon.tearDown.bind(null, t))


### PR DESCRIPTION
This adds 2 sync put tests, trying to recreate the failure from https://github.com/Level/leveldown/issues/157. On leveldown@master, this does __not__ cause a segfault for me. A `.put()` after the db is fully closed however does.

Once this is merged, we can add it to backends supporting `{ sync }`.