### PR TITLE
add isLevelDOWN() function

### DIFF
--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -242,18 +242,4 @@ AbstractLevelDOWN.prototype._checkKey = function (obj, type) {
     return new Error(type + ' cannot be an empty String')
 }
 
-function isLevelDOWN (db) {
-  if (!db || typeof db !== 'object')
-    return false
-  return Object.keys(AbstractLevelDOWN.prototype).filter(function (name) {
-    // TODO remove approximateSize check when method is gone
-    return name[0] != '_' && name != 'approximateSize'
-  }).every(function (name) {
-    return typeof db[name] == 'function'
-  })
-}
-
-exports.AbstractLevelDOWN    = AbstractLevelDOWN
-exports.AbstractIterator     = AbstractIterator
-exports.AbstractChainedBatch = AbstractChainedBatch
-exports.isLevelDOWN          = isLevelDOWN
+module.exports = AbstractLevelDOWN

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -242,6 +242,18 @@ AbstractLevelDOWN.prototype._checkKey = function (obj, type) {
     return new Error(type + ' cannot be an empty String')
 }
 
-module.exports.AbstractLevelDOWN    = AbstractLevelDOWN
-module.exports.AbstractIterator     = AbstractIterator
-module.exports.AbstractChainedBatch = AbstractChainedBatch
+function isLevelDOWN (db) {
+  if (!db || typeof db !== 'object')
+    return false
+  return Object.keys(AbstractLevelDOWN.prototype).filter(function (name) {
+    // TODO remove approximateSize check when method is gone
+    return name[0] != '_' && name != 'approximateSize'
+  }).every(function (name) {
+    return typeof db[name] == 'function'
+  })
+}
+
+exports.AbstractLevelDOWN    = AbstractLevelDOWN
+exports.AbstractIterator     = AbstractIterator
+exports.AbstractChainedBatch = AbstractChainedBatch
+exports.isLevelDOWN          = isLevelDOWN

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+exports.AbstractLevelDOWN    = require('./abstract-leveldown')
+exports.AbstractIterator     = require('./abstract-iterator')
+exports.AbstractChainedBatch = require('./abstract-chained-batch')
+exports.isLevelDOWN          = require('./is-leveldown')

--- a/is-leveldown.js
+++ b/is-leveldown.js
@@ -1,0 +1,14 @@
+const AbstractLevelDOWN = require('./abstract-leveldown')
+
+function isLevelDOWN (db) {
+  if (!db || typeof db !== 'object')
+    return false
+  return Object.keys(AbstractLevelDOWN.prototype).filter(function (name) {
+    // TODO remove approximateSize check when method is gone
+    return name[0] != '_' && name != 'approximateSize'
+  }).every(function (name) {
+    return typeof db[name] == 'function'
+  })
+}
+
+module.exports = isLevelDOWN

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "leveldown",
     "levelup"
   ],
-  "main": "./abstract-leveldown.js",
+  "main": "index.js",
   "dependencies": {
     "xtend": "~4.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ const test                 = require('tape')
     , AbstractLevelDOWN    = require('./').AbstractLevelDOWN
     , AbstractIterator     = require('./').AbstractIterator
     , AbstractChainedBatch = require('./').AbstractChainedBatch
+    , isLevelDOWN          = require('./').isLevelDOWN
 
 function factory (location) {
   return new AbstractLevelDOWN(location)
@@ -567,5 +568,33 @@ test('test end() extensibility', function (t) {
   t.equal(spy.getCall(0).thisValue, test, '`this` on _end() was correct')
   t.equal(spy.getCall(0).args.length, 1, 'got one arguments')
   t.equal(spy.getCall(0).args[0], expectedCb, 'got expected cb argument')
+  t.end()
+})
+
+test('isLevelDOWN', function (t) {
+  t.notOk(isLevelDOWN(), 'is not a leveldown')
+  t.notOk(isLevelDOWN(''), 'is not a leveldown')
+  t.notOk(isLevelDOWN({}), 'is not a leveldown')
+  t.notOk(isLevelDOWN({ put: function () {} }), 'is not a leveldown')
+  t.ok(isLevelDOWN(new AbstractLevelDOWN('location')), 'IS a leveldown')
+  t.ok(isLevelDOWN({
+    open: function () {},
+    close: function () {},
+    get: function () {},
+    put: function () {},
+    del: function () {},
+    batch: function () {},
+    iterator: function () {}
+  }), 'IS a leveldown')
+  t.ok(isLevelDOWN({
+    open: function () {},
+    close: function () {},
+    get: function () {},
+    put: function () {},
+    del: function () {},
+    batch: function () {},
+    approximateSize: function () {},
+    iterator: function () {}
+  }), 'IS also a leveldown')
   t.end()
 })


### PR DESCRIPTION
This adds the function `isLevelDOWN()` which I extracted from @substack 's commit https://github.com/substack/node-levelup/commit/cff0ae9fdf527569d20d48c73804dd8dafea2b59 (I'm cherry picking those commits to a new branch to make a new PR to levelup).

It basically makes sure the public api in `AbstractLevelDOWN` (except for the `approximateSize` method) is present in the given db object.