### PR TITLE
(#71) - remove `const`

### DIFF
--- a/is-leveldown.js
+++ b/is-leveldown.js
@@ -1,4 +1,4 @@
-const AbstractLevelDOWN = require('./abstract-leveldown')
+var AbstractLevelDOWN = require('./abstract-leveldown')
 
 function isLevelDOWN (db) {
   if (!db || typeof db !== 'object')

--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
-const test                 = require('tape')
-    , sinon                = require('sinon')
-    , util                 = require('util')
-    , testCommon           = require('./testCommon')
-    , AbstractLevelDOWN    = require('./').AbstractLevelDOWN
-    , AbstractIterator     = require('./').AbstractIterator
-    , AbstractChainedBatch = require('./').AbstractChainedBatch
-    , isLevelDOWN          = require('./').isLevelDOWN
+var test                 = require('tape')
+  , sinon                = require('sinon')
+  , util                 = require('util')
+  , testCommon           = require('./testCommon')
+  , AbstractLevelDOWN    = require('./').AbstractLevelDOWN
+  , AbstractIterator     = require('./').AbstractIterator
+  , AbstractChainedBatch = require('./').AbstractChainedBatch
+  , isLevelDOWN          = require('./').isLevelDOWN
 
 function factory (location) {
   return new AbstractLevelDOWN(location)


### PR DESCRIPTION
I know `const` is nice, but PouchDB is kind of depending on MemDOWN for certain browser builds, so it would be preferable to have it work in ES5-compatible browsers.