### PR TITLE
Only show build status for the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img alt="LevelDB Logo" height="100" src="http://leveldb.org/img/logo.svg">
 
-[![Build Status](https://secure.travis-ci.org/Level/abstract-leveldown.png)](http://travis-ci.org/Level/abstract-leveldown)
+[![Build Status](https://travis-ci.org/Level/abstract-leveldown.svg?branch=master)](http://travis-ci.org/Level/abstract-leveldown)
 [![dependencies](https://david-dm.org/Level/abstract-leveldown.svg)](https://david-dm.org/level/abstract-leveldown)
 
 [![NPM](https://nodei.co/npm/abstract-leveldown.png?downloads=true&downloadRank=true)](https://nodei.co/npm/abstract-leveldown/)


### PR DESCRIPTION
Since merging #77, the tests now run for all branches (which is good!). But the build status badge in the README.md showed the build status for the latest build - no matter the branch. So if a pull request failed its tests the main badge would show as failed on both npm and github.

This commit ensures that only the state of the master branch is reflected in the build status badge.

This commit also updates the badge URL to the latest recommend URL by Travis.