### PR TITLE
iterator-test: don't coerce values in the browser

### DIFF
--- a/abstract/iterator-test.js
+++ b/abstract/iterator-test.js
@@ -14,7 +14,7 @@ var db
       return d
     }())
   , transformSource = function (d) {
-      return { key: d.key, value: String(d.value) }
+      return { key: d.key, value: process.browser ? d.value : String(d.value) }
     }
 
 module.exports.sourceData      = sourceData


### PR DESCRIPTION
Currently trying to get native JS type support in [level-js](maxogden/level.js#46). This little patch is required to make all abstract tests pass in the browser.
