### PR TITLE
Remove stringification of keys and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ See [MemDOWN](https://github.com/Level/memdown/) if you are looking for a comple
 
 Remember that each of these methods, if you implement them, will receive exactly the number and order of arguments described. Optional arguments will be converted to sensible defaults.
 
-### AbstractLevelDOWN(location)
+### AbstractLevelDOWN(location, options)
+
+Available options:
+
+- `toBuffer`: Convert all keys and values to buffers. Default: `true`.
+
 ### AbstractLevelDOWN#_open(options, callback)
 ### AbstractLevelDOWN#_close(callback)
 ### AbstractLevelDOWN#_get(key, options, callback)

--- a/README.md
+++ b/README.md
@@ -89,12 +89,7 @@ See [MemDOWN](https://github.com/Level/memdown/) if you are looking for a comple
 
 Remember that each of these methods, if you implement them, will receive exactly the number and order of arguments described. Optional arguments will be converted to sensible defaults.
 
-### AbstractLevelDOWN(location, options)
-
-Available options:
-
-- `toBuffer`: Convert all keys and values to buffers. Default: `true`.
-
+### AbstractLevelDOWN(location)
 ### AbstractLevelDOWN#_open(options, callback)
 ### AbstractLevelDOWN#_close(callback)
 ### AbstractLevelDOWN#_get(key, options, callback)
@@ -109,6 +104,8 @@ If `batch()` is called without arguments or with only an options object then it 
 By default a `batch()` operation without arguments returns a blank `AbstractChainedBatch` object. The prototype is available on the main exports for you to extend. If you want to implement chainable batch operations then you should extend the `AbstractChaindBatch` and return your object in the `_chainedBatch()` method.
 
 ### AbstractLevelDOWN#_approximateSize(start, end, callback)
+### AbstractLevelDOWN#_serializeKey(key)
+### AbstractLevelDOWN#_serializeValue(value)
 ### AbstractLevelDOWN#_iterator(options)
 
 By default an `iterator()` operation returns a blank `AbstractIterator` object. The prototype is available on the main exports for you to extend. If you want to implement iterator operations then you should extend the `AbstractIterator` and return your object in the `_iterator(options)` method.
@@ -129,6 +126,8 @@ Provided with the current instance of `AbstractLevelDOWN` by default.
 ### AbstractChainedBatch#_del(key)
 ### AbstractChainedBatch#_clear()
 ### AbstractChainedBatch#_write(options, callback)
+### AbstractChainedBatch#_serializeKey(key)
+### AbstractChainedBatch#_serializeValue(value)
 
 ### isLevelDown(db)
 

--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -1,9 +1,13 @@
 /* Copyright (c) 2013 Rod Vagg, MIT License */
 
-function AbstractChainedBatch (db) {
+function AbstractChainedBatch (db, opts) {
+  opts             = opts || {}
   this._db         = db
   this._operations = []
   this._written    = false
+  this._toBuffer   = typeof opts.toBuffer != 'undefined'
+    ? opts.toBuffer
+    : true
 }
 
 AbstractChainedBatch.prototype._checkWritten = function () {
@@ -18,6 +22,11 @@ AbstractChainedBatch.prototype.put = function (key, value) {
   if (err)
     throw err
 
+  if (this._toBuffer) {
+    if (!this._db._isBuffer(key)) key = String(key)
+    if (!this._db._isBuffer(value)) value = String(value)
+  }
+
   if (typeof this._put == 'function' )
     this._put(key, value)
   else
@@ -31,6 +40,8 @@ AbstractChainedBatch.prototype.del = function (key) {
 
   var err = this._db._checkKey(key, 'key', this._db._isBuffer)
   if (err) throw err
+
+  if (this._toBuffer && !this._db._isBuffer(key)) key = String(key)
 
   if (typeof this._del == 'function' )
     this._del(key)

--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -18,9 +18,6 @@ AbstractChainedBatch.prototype.put = function (key, value) {
   if (err)
     throw err
 
-  if (!this._db._isBuffer(key)) key = String(key)
-  if (!this._db._isBuffer(value)) value = String(value)
-
   if (typeof this._put == 'function' )
     this._put(key, value)
   else
@@ -34,8 +31,6 @@ AbstractChainedBatch.prototype.del = function (key) {
 
   var err = this._db._checkKey(key, 'key', this._db._isBuffer)
   if (err) throw err
-
-  if (!this._db._isBuffer(key)) key = String(key)
 
   if (typeof this._del == 'function' )
     this._del(key)

--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -1,13 +1,17 @@
 /* Copyright (c) 2013 Rod Vagg, MIT License */
 
-function AbstractChainedBatch (db, opts) {
-  opts             = opts || {}
+function AbstractChainedBatch (db) {
   this._db         = db
   this._operations = []
   this._written    = false
-  this._toBuffer   = typeof opts.toBuffer != 'undefined'
-    ? opts.toBuffer
-    : true
+}
+
+AbstractChainedBatch.prototype._serializeKey = function (key) {
+  return this._db._serializeKey(key)
+}
+
+AbstractChainedBatch.prototype._serializeValue = function (value) {
+  return this._db._serializeValue(value)
 }
 
 AbstractChainedBatch.prototype._checkWritten = function () {
@@ -22,10 +26,8 @@ AbstractChainedBatch.prototype.put = function (key, value) {
   if (err)
     throw err
 
-  if (this._toBuffer) {
-    if (!this._db._isBuffer(key)) key = String(key)
-    if (!this._db._isBuffer(value)) value = String(value)
-  }
+  key = this._serializeKey(key)
+  value = this._serializeValue(value)
 
   if (typeof this._put == 'function' )
     this._put(key, value)
@@ -41,7 +43,7 @@ AbstractChainedBatch.prototype.del = function (key) {
   var err = this._db._checkKey(key, 'key', this._db._isBuffer)
   if (err) throw err
 
-  if (this._toBuffer && !this._db._isBuffer(key)) key = String(key)
+  key = this._serializeKey(key)
 
   if (typeof this._del == 'function' )
     this._del(key)

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -248,11 +248,15 @@ AbstractLevelDOWN.prototype._isBuffer = function (obj) {
 }
 
 AbstractLevelDOWN.prototype._serializeKey = function (key) {
-  if (!this._isBuffer(key)) return String(key)
+  return this._isBuffer(key)
+    ? key
+    : String(key)
 }
 
 AbstractLevelDOWN.prototype._serializeValue = function (value) {
-  if (!this._isBuffer(value) && !process.browser) return String(value)
+  return this._isBuffer(value) || process.browser
+    ? value
+    : String(value)
 }
 
 AbstractLevelDOWN.prototype._checkKey = function (obj, type) {

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -4,15 +4,19 @@ var xtend                = require('xtend')
   , AbstractIterator     = require('./abstract-iterator')
   , AbstractChainedBatch = require('./abstract-chained-batch')
 
-function AbstractLevelDOWN (location) {
+function AbstractLevelDOWN (location, opts) {
   if (!arguments.length || location === undefined)
     throw new Error('constructor requires at least a location argument')
 
   if (typeof location != 'string')
     throw new Error('constructor requires a location string argument')
 
+  opts = opts || {}
   this.location = location
   this.status = 'new'
+  this._toBuffer = typeof opts.toBuffer != 'undefined'
+    ? opts.toBuffer
+    : true
 }
 
 AbstractLevelDOWN.prototype.open = function (options, callback) {
@@ -82,6 +86,9 @@ AbstractLevelDOWN.prototype.get = function (key, options, callback) {
   if (err = this._checkKey(key, 'key'))
     return callback(err)
 
+  if (this._toBuffer && !this._isBuffer(key))
+    key = String(key)
+
   if (typeof options != 'object')
     options = {}
 
@@ -105,6 +112,16 @@ AbstractLevelDOWN.prototype.put = function (key, value, options, callback) {
   if (err = this._checkKey(key, 'key'))
     return callback(err)
 
+  if (this._toBuffer) {
+    if (!this._isBuffer(key))
+      key = String(key)
+
+    // coerce value to string in node, don't touch it in browser
+    // (indexeddb can store any JS type)
+    if (value != null && !this._isBuffer(value) && !process.browser)
+      value = String(value)
+  }
+
   if (typeof options != 'object')
     options = {}
 
@@ -126,6 +143,9 @@ AbstractLevelDOWN.prototype.del = function (key, options, callback) {
   if (err = this._checkKey(key, 'key'))
     return callback(err)
 
+  if (this._toBuffer && !this._isBuffer(key))
+    key = String(key)
+
   if (typeof options != 'object')
     options = {}
 
@@ -137,7 +157,9 @@ AbstractLevelDOWN.prototype.del = function (key, options, callback) {
 
 AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
   if (!arguments.length)
-    return this._chainedBatch()
+    return this._chainedBatch({
+      toBuffer: this._toBuffer
+    })
 
   if (typeof options == 'function')
     callback = options
@@ -189,6 +211,13 @@ AbstractLevelDOWN.prototype.approximateSize = function (start, end, callback) {
   if (typeof callback != 'function')
     throw new Error('approximateSize() requires a callback argument')
 
+  if (this._toBuffer) {
+    if (!this._isBuffer(start))
+      start = String(start)
+    if (!this._isBuffer(end))
+      end = String(end)
+  }
+
   if (typeof this._approximateSize == 'function')
     return this._approximateSize(start, end, callback)
 
@@ -229,8 +258,8 @@ AbstractLevelDOWN.prototype.iterator = function (options) {
   return new AbstractIterator(this)
 }
 
-AbstractLevelDOWN.prototype._chainedBatch = function () {
-  return new AbstractChainedBatch(this)
+AbstractLevelDOWN.prototype._chainedBatch = function (opts) {
+  return new AbstractChainedBatch(this, opts)
 }
 
 AbstractLevelDOWN.prototype._isBuffer = function (obj) {

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -82,9 +82,6 @@ AbstractLevelDOWN.prototype.get = function (key, options, callback) {
   if (err = this._checkKey(key, 'key'))
     return callback(err)
 
-  if (!this._isBuffer(key))
-    key = String(key)
-
   if (typeof options != 'object')
     options = {}
 
@@ -108,14 +105,6 @@ AbstractLevelDOWN.prototype.put = function (key, value, options, callback) {
   if (err = this._checkKey(key, 'key'))
     return callback(err)
 
-  if (!this._isBuffer(key))
-    key = String(key)
-
-  // coerce value to string in node, don't touch it in browser
-  // (indexeddb can store any JS type)
-  if (value != null && !this._isBuffer(value) && !process.browser)
-    value = String(value)
-
   if (typeof options != 'object')
     options = {}
 
@@ -136,9 +125,6 @@ AbstractLevelDOWN.prototype.del = function (key, options, callback) {
 
   if (err = this._checkKey(key, 'key'))
     return callback(err)
-
-  if (!this._isBuffer(key))
-    key = String(key)
 
   if (typeof options != 'object')
     options = {}
@@ -202,12 +188,6 @@ AbstractLevelDOWN.prototype.approximateSize = function (start, end, callback) {
 
   if (typeof callback != 'function')
     throw new Error('approximateSize() requires a callback argument')
-
-  if (!this._isBuffer(start))
-    start = String(start)
-
-  if (!this._isBuffer(end))
-    end = String(end)
 
   if (typeof this._approximateSize == 'function')
     return this._approximateSize(start, end, callback)

--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -1,8 +1,12 @@
 var db
+  , leveldown
+  , testCommon
 
-module.exports.setUp = function (leveldown, test, testCommon) {
-  test('setUp common', testCommon.setUp)
+module.exports.setUp = function (_leveldown, test, _testCommon) {
+  test('setUp common', _testCommon.setUp)
   test('setUp db', function (t) {
+    leveldown = _leveldown
+    testCommon = _testCommon
     db = leveldown(testCommon.location())
     db.open(t.end.bind(t))
   })
@@ -61,6 +65,21 @@ module.exports.args = function (test) {
       , '1-arg + callback approximateSize() throws'
     )
     t.end()
+  })
+
+  test('test pass through start and end', function (t) {
+    t.plan(3)
+    var db = leveldown(testCommon.location())
+    db._approximateSize = function (start, end, callback) {
+      t.deepEqual(start, { foo: 'bar' })
+      t.deepEqual(end, { beep: 'boop' })
+      callback()
+    }
+    db.open(function () {
+      db.approximateSize({ foo: 'bar' }, { beep: 'boop' }, function (err) {
+        t.error(err)
+      })
+    })
   })
 }
 

--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -67,9 +67,11 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test pass through start and end', function (t) {
+  test('test toBuffer=false', function (t) {
     t.plan(3)
-    var db = leveldown(testCommon.location())
+    var db = leveldown(testCommon.location(), {
+      toBuffer: false
+    })
     db._approximateSize = function (start, end, callback) {
       t.deepEqual(start, { foo: 'bar' })
       t.deepEqual(end, { beep: 'boop' })

--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -84,11 +84,11 @@ module.exports.args = function (test) {
     t.plan(3)
     var db = leveldown(testCommon.location())
     db._approximateSize = function (start, end, callback) {
-      t.ok(Buffer.isBuffer(start))
-      t.ok(Buffer.isBuffer(end))
+      t.same(start, Buffer('start'))
+      t.same(end, Buffer('end'))
       callback()
     }
-    db.approximateSize(Buffer('buf'), Buffer('buf'), function (err, val) {
+    db.approximateSize(Buffer('start'), Buffer('end'), function (err, val) {
       t.error(err)
     })
   })

--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -67,6 +67,32 @@ module.exports.args = function (test) {
     t.end()
   })
 
+  test('test _serialize object', function (t) {
+    t.plan(3)
+    var db = leveldown(testCommon.location())
+    db._approximateSize = function (start, end, callback) {
+      t.equal(start, '[object Object]')
+      t.equal(end, '[object Object]')
+      callback()
+    }
+    db.approximateSize({}, {}, function (err, val) {
+      t.error(err)
+    })
+  })
+
+  test('test _serialize buffer', function (t) {
+    t.plan(3)
+    var db = leveldown(testCommon.location())
+    db._approximateSize = function (start, end, callback) {
+      t.ok(Buffer.isBuffer(start))
+      t.ok(Buffer.isBuffer(end))
+      callback()
+    }
+    db.approximateSize(Buffer('buf'), Buffer('buf'), function (err, val) {
+      t.error(err)
+    })
+  })
+
   test('test custom _serialize*', function (t) {
     t.plan(3)
     var db = leveldown(testCommon.location())

--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -67,11 +67,10 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test toBuffer=false', function (t) {
+  test('test custom _serialize*', function (t) {
     t.plan(3)
-    var db = leveldown(testCommon.location(), {
-      toBuffer: false
-    })
+    var db = leveldown(testCommon.location())
+    db._serializeKey = function (data) { return data }
     db._approximateSize = function (start, end, callback) {
       t.deepEqual(start, { foo: 'bar' })
       t.deepEqual(end, { beep: 'boop' })

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -157,6 +157,27 @@ module.exports.args = function (test) {
     t.end()
   })
 
+  test('test serialize object', function (t) {
+    var batch = db.batch()
+      .put({ foo: 'bar' }, { beep: 'boop' })
+      .del({ bar: 'baz' })
+    t.deepEqual(batch._operations, [
+        { type: 'put', key: '[object Object]', value: '[object Object]' }
+      , { type: 'del', key: '[object Object]' }
+    ])
+    t.end()
+  })
+
+  test('test serialize buffer', function (t) {
+    var batch = db.batch()
+      .put(Buffer('foo'), Buffer('bar'))
+      .del(Buffer('baz'))
+    t.equal(batch._operations[0].key.toString(), 'foo')
+    t.equal(batch._operations[0].value.toString(), 'bar')
+    t.equal(batch._operations[1].key.toString(), 'baz')
+    t.end()
+  })
+
   test('test custom _serialize*', function (t) {
     var db = leveldown(testCommon.location())
     db._serializeKey = db._serializeValue = function (data) { return data }

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -152,6 +152,17 @@ module.exports.args = function (test) {
     t.fail('should have thrown')
     t.end()
   })
+
+  test('test pass through key and value', function (t) {
+    var batch = db.batch()
+      .put({ foo: 'bar' }, { beep: 'boop' })
+      .del({ bar: 'baz' })
+    t.deepEqual(batch._operations, [
+        { type: 'put', key: { foo: 'bar' }, value: { beep: 'boop' } }
+      , { type: 'del', key: { bar: 'baz' } }
+    ])
+    t.end()
+  })
 }
 
 module.exports.batch = function (test, testCommon) {

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -1,8 +1,12 @@
 var db
+  , leveldown
+  , testCommon
 
-module.exports.setUp = function (leveldown, test, testCommon) {
-  test('setUp common', testCommon.setUp)
+module.exports.setUp = function (_leveldown, test, _testCommon) {
+  test('setUp common', _testCommon.setUp)
   test('setUp db', function (t) {
+    leveldown = _leveldown
+    testCommon = _testCommon
     db = leveldown(testCommon.location())
     db.open(t.end.bind(t))
   })
@@ -153,15 +157,20 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test pass through key and value', function (t) {
-    var batch = db.batch()
-      .put({ foo: 'bar' }, { beep: 'boop' })
-      .del({ bar: 'baz' })
-    t.deepEqual(batch._operations, [
-        { type: 'put', key: { foo: 'bar' }, value: { beep: 'boop' } }
-      , { type: 'del', key: { bar: 'baz' } }
-    ])
-    t.end()
+  test('test toBuffer=false', function (t) {
+    var db = leveldown(testCommon.location(), {
+      toBuffer: false
+    })
+    db.open(function () {
+      var batch = db.batch()
+        .put({ foo: 'bar' }, { beep: 'boop' })
+        .del({ bar: 'baz' })
+      t.deepEqual(batch._operations, [
+          { type: 'put', key: { foo: 'bar' }, value: { beep: 'boop' } }
+        , { type: 'del', key: { bar: 'baz' } }
+      ])
+      db.close(t.end.bind(t))
+    })
   })
 }
 

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -157,10 +157,9 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test toBuffer=false', function (t) {
-    var db = leveldown(testCommon.location(), {
-      toBuffer: false
-    })
+  test('test custom _serialize*', function (t) {
+    var db = leveldown(testCommon.location())
+    db._serializeKey = db._serializeValue = function (data) { return data }
     db.open(function () {
       var batch = db.batch()
         .put({ foo: 'bar' }, { beep: 'boop' })

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -1,10 +1,14 @@
 var db
+  , leveldown
+  , testCommon
   , verifyNotFoundError = require('./util').verifyNotFoundError
   , isTypedArray        = require('./util').isTypedArray
 
-module.exports.setUp = function (leveldown, test, testCommon) {
-  test('setUp common', testCommon.setUp)
+module.exports.setUp = function (_leveldown, test, _testCommon) {
+  test('setUp common', _testCommon.setUp)
   test('setUp db', function (t) {
+    leveldown = _leveldown
+    testCommon = _testCommon
     db = leveldown(testCommon.location())
     db.open(t.end.bind(t))
   })
@@ -36,6 +40,20 @@ module.exports.args = function (test) {
       , 'callback-less, 2-arg del() throws'
     )
     t.end()
+  })
+
+  test('test pass through key', function (t) {
+    t.plan(2)
+    var db = leveldown(testCommon.location())
+    db._del = function (key, options, callback) {
+      t.deepEqual(key, { foo: 'bar' })
+      callback()
+    }
+    db.open(function () {
+      db.del({ foo: 'bar' }, function (err) {
+        t.error(err)
+      })
+    })
   })
 }
 

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -42,9 +42,11 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test pass through key', function (t) {
+  test('test toBuffer=false', function (t) {
     t.plan(2)
-    var db = leveldown(testCommon.location())
+    var db = leveldown(testCommon.location(), {
+      toBuffer: false
+    })
     db._del = function (key, options, callback) {
       t.deepEqual(key, { foo: 'bar' })
       callback()

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -42,6 +42,30 @@ module.exports.args = function (test) {
     t.end()
   })
 
+  test('test _serialize object', function (t) {
+    t.plan(2)
+    var db = leveldown(testCommon.location())
+    db._del = function (key, opts, callback) {
+      t.equal(key, '[object Object]')
+      callback()
+    }
+    db.del({}, function (err, val) {
+      t.error(err)
+    })
+  })
+
+  test('test _serialize buffer', function (t) {
+    t.plan(2)
+    var db = leveldown(testCommon.location())
+    db._del = function (key, opts, callback) {
+      t.ok(Buffer.isBuffer(key))
+      callback()
+    }
+    db.del(Buffer('buf'), function (err, val) {
+      t.error(err)
+    })
+  })
+
   test('test custom _serialize*', function (t) {
     t.plan(2)
     var db = leveldown(testCommon.location())

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -42,11 +42,10 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test toBuffer=false', function (t) {
+  test('test custom _serialize*', function (t) {
     t.plan(2)
-    var db = leveldown(testCommon.location(), {
-      toBuffer: false
-    })
+    var db = leveldown(testCommon.location())
+    db._serializeKey = function (data) { return data }
     db._del = function (key, options, callback) {
       t.deepEqual(key, { foo: 'bar' })
       callback()

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -42,6 +42,30 @@ module.exports.args = function (test) {
     t.end()
   })
 
+  test('test _serialize object', function (t) {
+    t.plan(2)
+    var db = leveldown(testCommon.location())
+    db._get = function (key, opts, callback) {
+      t.equal(key, '[object Object]')
+      callback()
+    }
+    db.get({}, function (err, val) {
+      t.error(err)
+    })
+  })
+
+  test('test _serialize buffer', function (t) {
+    t.plan(2)
+    var db = leveldown(testCommon.location())
+    db._get = function (key, opts, callback) {
+      t.ok(Buffer.isBuffer(key))
+      callback()
+    }
+    db.get(Buffer('buf'), function (err, val) {
+      t.error(err)
+    })
+  })
+
   test('test custom _serialize*', function (t) {
     t.plan(2)
     var db = leveldown(testCommon.location())

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -42,9 +42,11 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test pass through key', function (t) {
+  test('test toBuffer=false', function (t) {
     t.plan(2)
-    var db = leveldown(testCommon.location())
+    var db = leveldown(testCommon.location(), {
+      toBuffer: false
+    })
     db._get = function (key, options, callback) {
       t.deepEqual(key, { foo: 'bar' })
       callback()

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -1,10 +1,14 @@
 var db
+  , leveldown
+  , testCommon
   , verifyNotFoundError = require('./util').verifyNotFoundError
   , isTypedArray        = require('./util').isTypedArray
 
-module.exports.setUp = function (leveldown, test, testCommon) {
-  test('setUp common', testCommon.setUp)
+module.exports.setUp = function (_leveldown, test, _testCommon) {
+  test('setUp common', _testCommon.setUp)
   test('setUp db', function (t) {
+    leveldown = _leveldown
+    testCommon = _testCommon
     db = leveldown(testCommon.location())
     db.open(t.end.bind(t))
   })
@@ -36,6 +40,20 @@ module.exports.args = function (test) {
       , 'callback-less, 2-arg get() throws'
     )
     t.end()
+  })
+
+  test('test pass through key', function (t) {
+    t.plan(2)
+    var db = leveldown(testCommon.location())
+    db._get = function (key, options, callback) {
+      t.deepEqual(key, { foo: 'bar' })
+      callback()
+    }
+    db.open(function () {
+      db.get({ foo: 'bar' }, function (err) {
+        t.error(err)
+      })
+    })
   })
 }
 

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -42,11 +42,10 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test toBuffer=false', function (t) {
+  test('test custom _serialize*', function (t) {
     t.plan(2)
-    var db = leveldown(testCommon.location(), {
-      toBuffer: false
-    })
+    var db = leveldown(testCommon.location())
+    db._serializeKey = function (data) { return data }
     db._get = function (key, options, callback) {
       t.deepEqual(key, { foo: 'bar' })
       callback()

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -58,10 +58,10 @@ module.exports.args = function (test) {
     t.plan(2)
     var db = leveldown(testCommon.location())
     db._get = function (key, opts, callback) {
-      t.ok(Buffer.isBuffer(key))
+      t.same(key, Buffer('key'))
       callback()
     }
-    db.get(Buffer('buf'), function (err, val) {
+    db.get(Buffer('key'), function (err, val) {
       t.error(err)
     })
   })

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -51,6 +51,32 @@ module.exports.args = function (test) {
     t.end()
   })
 
+  test('test _serialize object', function (t) {
+    t.plan(3)
+    var db = leveldown(testCommon.location())
+    db._put = function (key, value, opts, callback) {
+      t.equal(key, '[object Object]')
+      t.equal(value, '[object Object]')
+      callback()
+    }
+    db.put({}, {}, function (err, val) {
+      t.error(err)
+    })
+  })
+
+  test('test _serialize buffer', function (t) {
+    t.plan(3)
+    var db = leveldown(testCommon.location())
+    db._put = function (key, value, opts, callback) {
+      t.ok(Buffer.isBuffer(key))
+      t.ok(Buffer.isBuffer(value))
+      callback()
+    }
+    db.put(Buffer('buf'), Buffer('buf'), function (err, val) {
+      t.error(err)
+    })
+  })
+
   test('test custom _serialize*', function (t) {
     t.plan(3)
     var db = leveldown(testCommon.location())

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -1,10 +1,14 @@
 var db
+  , leveldown
+  , testCommon
   , verifyNotFoundError = require('./util').verifyNotFoundError
   , isTypedArray        = require('./util').isTypedArray
 
-module.exports.setUp = function (leveldown, test, testCommon) {
-  test('setUp common', testCommon.setUp)
+module.exports.setUp = function (_leveldown, test, _testCommon) {
+  test('setUp common', _testCommon.setUp)
   test('setUp db', function (t) {
+    leveldown = _leveldown
+    testCommon = _testCommon
     db = leveldown(testCommon.location())
     db.open(t.end.bind(t))
   })
@@ -45,6 +49,21 @@ module.exports.args = function (test) {
       , 'callback-less, 3-arg put() throws'
     )
     t.end()
+  })
+
+  test('test pass through key and value', function (t) {
+    t.plan(3)
+    var db = leveldown(testCommon.location())
+    db._put = function (key, value, options, callback) {
+      t.deepEqual(key, { foo: 'bar' })
+      t.deepEqual(value, { beep: 'boop' })
+      callback()
+    }
+    db.open(function () {
+      db.put({ foo: 'bar' }, { beep: 'boop'}, function (err) {
+        t.error(err)
+      })
+    })
   })
 }
 

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -68,11 +68,11 @@ module.exports.args = function (test) {
     t.plan(3)
     var db = leveldown(testCommon.location())
     db._put = function (key, value, opts, callback) {
-      t.ok(Buffer.isBuffer(key))
-      t.ok(Buffer.isBuffer(value))
+      t.same(key, Buffer('key'))
+      t.same(value, Buffer('value'))
       callback()
     }
-    db.put(Buffer('buf'), Buffer('buf'), function (err, val) {
+    db.put(Buffer('key'), Buffer('value'), function (err, val) {
       t.error(err)
     })
   })

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -51,9 +51,11 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test pass through key and value', function (t) {
+  test('test toBuffer=false', function (t) {
     t.plan(3)
-    var db = leveldown(testCommon.location())
+    var db = leveldown(testCommon.location(), {
+      toBuffer: false
+    })
     db._put = function (key, value, options, callback) {
       t.deepEqual(key, { foo: 'bar' })
       t.deepEqual(value, { beep: 'boop' })

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -51,11 +51,10 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test toBuffer=false', function (t) {
+  test('test custom _serialize*', function (t) {
     t.plan(3)
-    var db = leveldown(testCommon.location(), {
-      toBuffer: false
-    })
+    var db = leveldown(testCommon.location())
+    db._serializeKey = db._serializeValue = function (data) { return data }
     db._put = function (key, value, options, callback) {
       t.deepEqual(key, { foo: 'bar' })
       t.deepEqual(value, { beep: 'boop' })

--- a/test.js
+++ b/test.js
@@ -7,8 +7,8 @@ var test                 = require('tape')
   , AbstractChainedBatch = require('./').AbstractChainedBatch
   , isLevelDOWN          = require('./').isLevelDOWN
 
-function factory (location) {
-  return new AbstractLevelDOWN(location)
+function factory (location, opts) {
+  return new AbstractLevelDOWN(location, opts)
 }
 
 /*** compatibility with basic LevelDOWN API ***/
@@ -712,3 +712,4 @@ test('.status', function (t) {
     })
   })
 })
+


### PR DESCRIPTION
levelup handles massaging keys and values through its encoding layer already. However, if the user passed `encoding: 'id'`, abstract-leveldown would still convert everything to a string or buffer. For those encodings, like level.js and postgres-down that do support more of the native JS values, this gives them the chance of receiving the raw values and encoding them themselves.

It's a breaking change and so if merged will need a `3.0.0` release.