### PR TITLE
Buffer _put/_del inputs in chained batch tests

### DIFF
--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -202,7 +202,6 @@ module.exports.args = function (test) {
   })
 
   test('test custom _serialize*', function (t) {
-    // create a delegate db and patch _serialize* method with identity function
     var _db = Object.create(db)
     _db._serializeKey = _db._serializeValue = function (data) { return data }
 

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -5,9 +5,8 @@ function collectBatchOps (batch) {
     , _del        = batch._del
     , _operations = []
 
-  if (typeof _put !== 'function' || typeof _del !== 'function') {
+  if (typeof _put !== 'function' || typeof _del !== 'function')
     return batch._operations
-  }
 
   batch._put = function (key, value) {
     _operations.push({ type: 'put', key: key, value: value })

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -202,13 +202,12 @@ module.exports.args = function (test) {
   })
 
   test('test custom _serialize*', function (t) {
-    var batch           = db.batch()
-      , ops             = collectBatchOps(batch)
-      , _serializeKey   = db._serializeKey
-      , _serializeValue = db._serializeValue
+    // create a delegate db and patch _serialize* method with identity function
+    var _db = Object.create(db)
+    _db._serializeKey = _db._serializeValue = function (data) { return data }
 
-    // patch _serialize* with identity function
-    db._serializeKey = db._serializeValue = function (data) { return data }
+    var batch = _db.batch()
+      , ops   = collectBatchOps(batch)
 
     batch
       .put({ foo: 'bar' }, { beep: 'boop' })
@@ -219,9 +218,6 @@ module.exports.args = function (test) {
       , { type: 'del', key: { bar: 'baz' } }
     ])
 
-    // remove _serialize* patch
-    db._serializeKey = _serializeKey
-    db._serializeValue = _serializeValue
     t.end()
   })
 }


### PR DESCRIPTION
This PR addresses the main problem w/ the chained batch tests mentioned in #87 -- the tests assume an `_operations` buffer is kept in chained batch. This fixes the tests to capture the inputs that _would_ go to an `_operations` buffer, which is the data these tests are trying to introspecting.

/cc @ralphtheninja @juliangruber 
