### PR TITLE
Expose a hook to verify approximate size

### DIFF
--- a/testCommon.js
+++ b/testCommon.js
@@ -65,6 +65,15 @@ var dbidx = 0
       next()
     }
 
+  , checkBatchSize = function (batch, approximateSize) {
+      var maxCompressionFactor = 0.04 // accounts for snappy compression
+        , total = batch.reduce(function (n, op) {
+            return n + (op.key + op.value).length
+          }, 0)
+
+      return approximateSize > total * maxCompressionFactor
+    }
+
 module.exports = {
     location       : location
   , cleanup        : cleanup
@@ -72,4 +81,5 @@ module.exports = {
   , setUp          : setUp
   , tearDown       : tearDown
   , collectEntries : collectEntries
+  , checkBatchSize : checkBatchSize
 }


### PR DESCRIPTION
We need this to enable the `approximateSize` tests in `pgdown` -- `TOAST` compression looks to be around 4x better than `snappy` so the hardcoded `40000` won't cut it. While I was at it I figured it wouldn't hurt to pass in the whole batch to allow implementations to test the approximate size however they see fit.

/cc @ralphtheninja @juliangruber 