### PR TITLE
Allow serialization functions to return buffers

### DIFF
--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -71,8 +71,8 @@ module.exports.args = function (test) {
     t.plan(3)
     var db = leveldown(testCommon.location())
     db._approximateSize = function (start, end, callback) {
-      t.equal(start, '[object Object]')
-      t.equal(end, '[object Object]')
+      t.equal(Buffer.isBuffer(start) ? String(start) : start, '[object Object]')
+      t.equal(Buffer.isBuffer(end) ? String(end) : end, '[object Object]')
       callback()
     }
     db.approximateSize({}, {}, function (err, val) {

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -181,6 +181,10 @@ module.exports.args = function (test) {
     batch
       .put({ foo: 'bar' }, { beep: 'boop' })
       .del({ bar: 'baz' })
+    ops.forEach(function (op) {
+      if (Buffer.isBuffer(op.key)) op.key = String(op.key)
+      if (Buffer.isBuffer(op.value)) op.value = String(op.value)
+    })
     t.deepEqual(ops, [
         { type: 'put', key: '[object Object]', value: '[object Object]' }
       , { type: 'del', key: '[object Object]' }

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -46,7 +46,7 @@ module.exports.args = function (test) {
     t.plan(2)
     var db = leveldown(testCommon.location())
     db._del = function (key, opts, callback) {
-      t.equal(key, '[object Object]')
+      t.equal(Buffer.isBuffer(key) ? String(key) : key, '[object Object]')
       callback()
     }
     db.del({}, function (err, val) {

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -46,7 +46,7 @@ module.exports.args = function (test) {
     t.plan(2)
     var db = leveldown(testCommon.location())
     db._get = function (key, opts, callback) {
-      t.equal(key, '[object Object]')
+      t.equal(Buffer.isBuffer(key) ? String(key) : key, '[object Object]')
       callback()
     }
     db.get({}, function (err, val) {

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -55,8 +55,8 @@ module.exports.args = function (test) {
     t.plan(3)
     var db = leveldown(testCommon.location())
     db._put = function (key, value, opts, callback) {
-      t.equal(key, '[object Object]')
-      t.equal(value, '[object Object]')
+      t.equal(Buffer.isBuffer(key) ? String(key) : key, '[object Object]')
+      t.equal(Buffer.isBuffer(value) ? String(value) : value, '[object Object]')
       callback()
     }
     db.put({}, {}, function (err, val) {


### PR DESCRIPTION
This just loosens up the tests to allow _serlialize* functions to force buffers
for string keys or values. The underlying store impl might prefer (or require) buffers.

/cc @juliangruber @ralphtheninja 