### PR TITLE
Run/fix tests in the browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,29 @@ language: node_js
 
 node_js:
   - "5"
-  - "4"
-  - "3"
-  - "2"
-  - "1.8"
-  - "1.0"
-  - "0.12"
-  - "0.10"
+
+script: npm run $COMMAND
+
+env:
+  matrix:
+    - COMMAND=test
+    - COMMAND=test-browser
+matrix:
+  include:
+    - node_js: "0.10"
+      env: COMMAND=test
+    - node_js: "0.12"
+      env: COMMAND=test
+    - node_js: "1.0"
+      env: COMMAND=test
+    - node_js: "1.8"
+      env: COMMAND=test
+    - node_js: "2"
+      env: COMMAND=test
+    - node_js: "3"
+      env: COMMAND=test
+    - node_js: "4"
+      env: COMMAND=test
 
 notifications:
   email:

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -185,10 +185,17 @@ module.exports.args = function (test) {
       if (Buffer.isBuffer(op.key)) op.key = String(op.key)
       if (Buffer.isBuffer(op.value)) op.value = String(op.value)
     })
-    t.deepEqual(ops, [
-        { type: 'put', key: '[object Object]', value: '[object Object]' }
-      , { type: 'del', key: '[object Object]' }
-    ])
+    var expected = process.browser ?
+      [
+          { type: 'put', key: '[object Object]', value: {beep: 'boop'} }
+        , { type: 'del', key: '[object Object]' }
+      ] :
+      [
+          { type: 'put', key: '[object Object]', value: '[object Object]' }
+        , { type: 'del', key: '[object Object]' }
+      ];
+    console.log('expected');
+    t.deepEqual(ops, expected)
     t.end()
   })
 

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -56,7 +56,7 @@ module.exports.args = function (test) {
     var db = leveldown(testCommon.location())
     db._put = function (key, value, opts, callback) {
       t.equal(Buffer.isBuffer(key) ? String(key) : key, '[object Object]')
-      t.equal(Buffer.isBuffer(value) ? String(value) : value, '[object Object]')
+      t.deepEqual(Buffer.isBuffer(value) ? String(value) : value, process.browser ? {} : '[object Object]')
       callback()
     }
     db.put({}, {}, function (err, val) {

--- a/package.json
+++ b/package.json
@@ -33,15 +33,18 @@
     "xtend": "~4.0.0"
   },
   "devDependencies": {
+    "phantomjs-prebuilt": "^2.1.7",
     "rimraf": "~2.5.0",
     "sinon": "~1.17.2",
-    "tape": "~4.5.0"
+    "tape": "~4.5.0",
+    "zuul": "^3.10.1"
   },
   "browser": {
     "rimraf": false
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "node test.js",
+    "test-browser": "zuul --phantom --no-coverage --ui tape test.js"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
The abstract-leveldown tests currently fail in the browser. This fixes
the test and also adds new Travis tests using PhantomJS.
