### PR TITLE
do not store string 'null' or 'undefined'

### DIFF
--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -256,7 +256,7 @@ AbstractLevelDOWN.prototype._serializeKey = function (key) {
 AbstractLevelDOWN.prototype._serializeValue = function (value) {
   return this._isBuffer(value) || process.browser
     ? value
-    : String(value)
+    : String(value || '')
 }
 
 AbstractLevelDOWN.prototype._checkKey = function (obj, type) {


### PR DESCRIPTION
String(null) goes to 'null'

So null is not stored correctly, memdown test a failing