### PR TITLE
fix put test on object serialization

### DIFF
--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -55,8 +55,8 @@ module.exports.args = function (test) {
     t.plan(3)
     var db = leveldown(testCommon.location())
     db._put = function (key, value, opts, callback) {
-      t.equal(Buffer.isBuffer(key) ? String(key) : key, '[object Object]')
-      t.equal(Buffer.isBuffer(value) ? String(value) : value, '[object Object]')
+      t.ok(key)
+      t.ok(value)
       callback()
     }
     db.put({}, {}, function (err, val) {

--- a/test.js
+++ b/test.js
@@ -568,6 +568,38 @@ test('test end() extensibility', function (t) {
   t.end()
 })
 
+test('test serialization extensibility', function (t) {
+  var spy = sinon.spy()
+    , test
+
+  function Test (location) {
+    AbstractLevelDOWN.call(this, location)
+  }
+
+  util.inherits(Test, AbstractLevelDOWN)
+
+  Test.prototype._serializeKey = function (key) {
+    t.equal(key, 'no')
+    return 'foo'
+  }
+
+  Test.prototype._serializeValue = function (value) {
+    t.equal(value, 'nope')
+    return 'bar'
+  }
+
+  Test.prototype._put = spy
+
+  test = new Test('foobar')
+  test.put('no', 'nope', function () {})
+
+  t.equal(spy.callCount, 1, 'got _put() call')
+  t.equal(spy.getCall(0).args[0], 'foo', 'got expected key argument')
+  t.equal(spy.getCall(0).args[1], 'bar', 'got expected value argument')
+
+  t.end()
+})
+
 test('isLevelDOWN', function (t) {
   t.notOk(isLevelDOWN(), 'is not a leveldown')
   t.notOk(isLevelDOWN(''), 'is not a leveldown')
@@ -712,4 +744,3 @@ test('.status', function (t) {
     })
   })
 })
-


### PR DESCRIPTION
fixes https://github.com/Level/memdown/pull/57

Since abstract-leveldown implementers can choose to override `._serialize*` as they please, we really can't tell what kind of value we're getting. Simply checking for truthiness is like a smoke test for this behavior.

cc @nolanlawson @vweevers 
