### PR TITLE
add checks for batch with null value

### DIFF
--- a/abstract/batch-test.js
+++ b/abstract/batch-test.js
@@ -19,14 +19,22 @@ module.exports.args = function (test) {
   test('test batch() with missing `value`', function (t) {
     db.batch([{ type: 'put', key: 'foo1' }], function (err) {
       t.error(err)
-      t.end()
+      db.get('foo1', function (err, value) {
+        t.notOk(err, 'no error')
+        t.equal(value, null)
+        t.end()
+      })
     })
   })
 
   test('test batch() with null `value`', function (t) {
     db.batch([{ type: 'put', key: 'foo1', value: null }], function (err) {
       t.error(err)
-      t.end()
+      db.get('foo1', function (err, value) {
+        t.notOk(err, 'no error')
+        t.equal(value, null)
+        t.end()
+      })
     })
   })
 


### PR DESCRIPTION
seems these both fail with leveldown, memdown and probably other implementations

what is the expected behavior? If there is no error on put, then it should probably mean it successfully wrote a null value.