### PR TITLE
feat: add generic typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ declare namespace Abstract {
       TDeleteOptions=any,
       TIteratorOptions=any,
       TBatchOptions=any
-      >(db: any): LevelDOWN<
+      >(location: string): LevelDOWN<
       TKey,
       TValue,
       TOptions,
@@ -53,7 +53,7 @@ declare namespace Abstract {
       TDeleteOptions=any,
       TIteratorOptions=any,
       TBatchOptions=any
-      >(db: any): LevelDOWN<
+      >(location: string): LevelDOWN<
       TKey,
       TValue,
       TOptions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,97 @@
+declare namespace Abstract {
+  interface LevelDOWN<
+    TKey=any,
+    TValue=any,
+    TOptions=any,
+    TPutOptions=any,
+    TGetOptions=any,
+    TDeleteOptions=any,
+    TIteratorOptions=any,
+    TBatchOptions=any> {
+    open(callback: any): void;
+    open(options: TOptions, callback: any): void;
+    close(callback: any): void;
+    get(key: TKey, callback: any): void;
+    get(key: TKey, options: TGetOptions, callback: any): void;
+    put(key: TKey, value: TValue, callback: any): void;
+    put(key: TKey, value: TValue, options: TPutOptions, callback: any): void;
+    del(key: TKey, callback: any): void;
+    del(key: TKey, options: TDeleteOptions, callback: any): void;
+    batch(): ChainedBatch<TKey, TValue>
+    batch(array: any[], callback: any): any;
+    batch(array: any[], options: TBatchOptions, callback: any): any;
+    iterator(options?: TIteratorOptions): Iterator
+    [index: string]: any;
+  }
+
+  interface LevelDOWNConstructor {
+    new
+      <
+      TKey=any,
+      TValue=any,
+      TOptions=any,
+      TPutOptions=any,
+      TGetOptions=any,
+      TDeleteOptions=any,
+      TIteratorOptions=any,
+      TBatchOptions=any
+      >(db: any): LevelDOWN<
+      TKey,
+      TValue,
+      TOptions,
+      TPutOptions,
+      TGetOptions,
+      TDeleteOptions,
+      TIteratorOptions,
+      TBatchOptions>;
+    <
+      TKey=any,
+      TValue=any,
+      TOptions=any,
+      TPutOptions=any,
+      TGetOptions=any,
+      TDeleteOptions=any,
+      TIteratorOptions=any,
+      TBatchOptions=any
+      >(db: any): LevelDOWN<
+      TKey,
+      TValue,
+      TOptions,
+      TPutOptions,
+      TGetOptions,
+      TDeleteOptions,
+      TIteratorOptions,
+      TBatchOptions>
+  }
+
+  interface Iterator {
+    next(callback: any): void;
+    end(callback: any): void;
+    [index: string]: any;
+  }
+  interface IteratorConstructor {
+    new(db: any): Iterator;
+    (db: any): Iterator;
+  }
+
+  interface ChainedBatch<TKey=any, TValue=any> {
+    put(key: TKey, value: TValue): this;
+    del(key: TKey): this;
+    clear(): this;
+    write(callback: any): any
+    write(options: any, callback: any): any
+    [index: string]: any;
+  }
+
+  interface ChainedBatchConstructor {
+    new <TKey, TValue>(db: any): ChainedBatch<TKey, TValue>;
+    <TKey, TValue>(db: any): ChainedBatch<TKey, TValue>;
+  }
+
+  export const AbstractIterator: IteratorConstructor & Iterator;
+  export const AbstractLevelDOWN: LevelDOWNConstructor & LevelDOWN;
+  export const AbstractChainedBatch: ChainedBatchConstructor & ChainedBatch;
+  export function isLevelDOWN(db: any): boolean;
+}
+
+export = Abstract;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "levelup"
   ],
   "main": "index.js",
+  "typings": "index.d.ts",
   "dependencies": {
     "xtend": "~4.0.0"
   },


### PR DESCRIPTION
* serves as the basis types for levelUP's db typings. 
* while there is a lot of generics, they allow for levelup's typing to infer them directly from the db passed to it. 
* used locally with current levelup and passes levelup's tests. 
* I've added an indexer on each interface to derived classes can access anything not defined without typing error. 