### PR TITLE
refactor(typings): add missing types and simplify.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,97 +1,85 @@
-declare namespace Abstract {
-  interface LevelDOWN<
-    TKey=any,
-    TValue=any,
-    TOptions=any,
-    TPutOptions=any,
-    TGetOptions=any,
-    TDeleteOptions=any,
-    TIteratorOptions=any,
-    TBatchOptions=any> {
-    open(callback: any): void;
-    open(options: TOptions, callback: any): void;
-    close(callback: any): void;
-    get(key: TKey, callback: any): void;
-    get(key: TKey, options: TGetOptions, callback: any): void;
-    put(key: TKey, value: TValue, callback: any): void;
-    put(key: TKey, value: TValue, options: TPutOptions, callback: any): void;
-    del(key: TKey, callback: any): void;
-    del(key: TKey, options: TDeleteOptions, callback: any): void;
-    batch(): ChainedBatch<TKey, TValue>
-    batch(array: any[], callback: any): any;
-    batch(array: any[], options: TBatchOptions, callback: any): any;
-    iterator(options?: TIteratorOptions): Iterator
-    [index: string]: any;
-  }
+interface AbstractLevelDOWN<K=any, V=any, O=any, PO=any, GO=any, DO=any, IO=any, BO=any> {
+  open(callback: (err?: any) => void);
+  open(options: O, callback: (err?: any) => void);
 
-  interface LevelDOWNConstructor {
-    new
-      <
-      TKey=any,
-      TValue=any,
-      TOptions=any,
-      TPutOptions=any,
-      TGetOptions=any,
-      TDeleteOptions=any,
-      TIteratorOptions=any,
-      TBatchOptions=any
-      >(location: string): LevelDOWN<
-      TKey,
-      TValue,
-      TOptions,
-      TPutOptions,
-      TGetOptions,
-      TDeleteOptions,
-      TIteratorOptions,
-      TBatchOptions>;
-    <
-      TKey=any,
-      TValue=any,
-      TOptions=any,
-      TPutOptions=any,
-      TGetOptions=any,
-      TDeleteOptions=any,
-      TIteratorOptions=any,
-      TBatchOptions=any
-      >(location: string): LevelDOWN<
-      TKey,
-      TValue,
-      TOptions,
-      TPutOptions,
-      TGetOptions,
-      TDeleteOptions,
-      TIteratorOptions,
-      TBatchOptions>
-  }
+  close(callback: (err?: any) => void);
 
-  interface Iterator {
-    next(callback: any): void;
-    end(callback: any): void;
-    [index: string]: any;
-  }
-  interface IteratorConstructor {
-    new(db: any): Iterator;
-    (db: any): Iterator;
-  }
+  get(key: K, callback: (err, value: V) => any);
+  get(key: K, options: GO, callback: (err, value: V) => any);
 
-  interface ChainedBatch<TKey=any, TValue=any> {
-    put(key: TKey, value: TValue): this;
-    del(key: TKey): this;
-    clear(): this;
-    write(callback: any): any
-    write(options: any, callback: any): any
-    [index: string]: any;
-  }
+  put(key: K, value: V, callback: (err: any) => any);
+  put(key: K, value: V, options: PO, callback: (err: any) => any);
 
-  interface ChainedBatchConstructor {
-    new <TKey, TValue>(db: any): ChainedBatch<TKey, TValue>;
-    <TKey, TValue>(db: any): ChainedBatch<TKey, TValue>;
-  }
+  del(key: K, callback: (err: any) => any);
+  del(key: K, options: DO, callback: (err: any) => any);
 
-  export const AbstractIterator: IteratorConstructor & Iterator;
-  export const AbstractLevelDOWN: LevelDOWNConstructor & LevelDOWN;
-  export const AbstractChainedBatch: ChainedBatchConstructor & ChainedBatch;
-  export function isLevelDOWN(db: any): boolean;
+  batch(): AbstractChainedBatch<K, V, BO>;
+  batch(array: Batch<K, V>[], callback: (err: any) => any);
+  batch(array: Batch<K, V>[], options: BO, callback: (err: any) => any);
+
+  iterator(options?: IO & AbstractIteratorOptions<K>): AbstractIterator<K, V>;
+
+  approximateSize(start: K, end: K, cb: (err: any, size: number) => void): void;
+
+  [index: string]: any;
 }
 
-export = Abstract;
+interface AbstractLevelDOWNConstructor {
+  new <K=any, V=any, O=any, PO=any, GO=any, DO=any, IO=any, BO=any>(location: string): AbstractLevelDOWN<
+    K, V, O, PO, GO, DO, IO, BO>;
+  <K=any, V=any, O=any, PO=any, GO=any, DO=any, IO=any, BO=any>(location: string): AbstractLevelDOWN<
+    K, V, O, PO, GO, DO, IO, BO>;
+}
+
+export interface AbstractIteratorOptions<K=any> {
+  gt?: K;
+  gte?: K;
+  lt?: K;
+  lte?: K;
+  reverse?: boolean;
+  limit?: number;
+  keys?: boolean;
+  values?: boolean;
+}
+
+export type Batch<K=any, V=any> = PutBatch<K, V> | DelBatch<K>
+
+export interface PutBatch<K=any, V=any> {
+  type: 'put',
+  key: K,
+  value: V
+}
+
+export interface DelBatch<K=any, V=any> {
+  type: 'del',
+  key: K
+}
+
+interface AbstractIterator<K=any, V=any> {
+  next(callback: (err: any, key: K, value: V) => void): void;
+  end(callback: (err: any) => void): void;
+}
+
+interface AbstractIteratorConstructor {
+  new <K=any, V=any>(db: any): AbstractIterator<K, V>;
+  <K=any, V=any>(db: any): AbstractIterator<K, V>;
+}
+
+interface AbstractChainedBatch<K=any, V=any, BO=any> extends AbstractChainedBatchConstructor {
+  put(key: K, value: V): this;
+  del(key: K): this;
+  clear(): this;
+  write(callback: any): any
+  write(options: BO, callback: any): any
+  [index: string]: any;
+}
+
+interface AbstractChainedBatchConstructor {
+  new <K, V, BO>(db: any): AbstractChainedBatch<K, V, BO>;
+  <K, V, BO>(db: any): AbstractChainedBatch<K, V, BO>;
+}
+
+export const AbstractLevelDOWN: AbstractLevelDOWNConstructor
+export const AbstractIterator: AbstractIteratorConstructor
+export const AbstractChainedBatch: AbstractChainedBatchConstructor
+export function isLevelDOWN(db: any): boolean;


### PR DESCRIPTION
*~~In the js files i've explicitly defined the abstract methods (as undefined). run-time wise it should _not_ make a difference as they are still equal to `undefined` - but it allows the ts compiler to stay happy when checking the js. This was an issue for me locally, as the `levelup` ts-test was throwing errors when the package was linked.~~ 

* moved batch and common iterator options into the abstract typings as they were missing.  
* reworked typings as es2015 module. 
* breaking. publish as minor. 


cc: @zixia you're using typescript? If so mind having a quick review of this?