### PR TITLE
Abstract tests: use strings for values

### DIFF
--- a/abstract/iterator-test.js
+++ b/abstract/iterator-test.js
@@ -8,13 +8,13 @@ var db
         d.push({
             type  : 'put'
           , key   : k
-          , value : Math.random()
+          , value : String(Math.random())
         })
       }
       return d
     }())
   , transformSource = function (d) {
-      return { key: d.key, value: String(d.value) }
+      return { key: d.key, value: d.value }
     }
 
 module.exports.sourceData      = sourceData


### PR DESCRIPTION
As discussed in #137.

This means that memdown can do:

```js
MemDOWN.prototype._serializeKey = function (key) {
  return this._isBuffer(key)
    ? key
    : String(key)
}

MemDOWN.prototype._serializeValue = function (value) {
  if (value == null) return ''
  return value
}
```

Instead of the default implementation of `_serializeValue`:

```js
MemDOWN.prototype._serializeValue = function (value) {
  if (value == null) return ''
  return this._isBuffer(value) || process.browser ? value : String(value)
}
```