### PR TITLE
Remove serialize buffer tests

### DIFF
--- a/abstract/approximate-size-test.js
+++ b/abstract/approximate-size-test.js
@@ -67,19 +67,6 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test _serialize buffer', function (t) {
-    t.plan(3)
-    var db = leveldown(testCommon.location())
-    db._approximateSize = function (start, end, callback) {
-      t.same(start, Buffer.from('start'))
-      t.same(end, Buffer.from('end'))
-      callback()
-    }
-    db.approximateSize(Buffer.from('start'), Buffer.from('end'), function (err, val) {
-      t.error(err)
-    })
-  })
-
   test('test custom _serialize*', function (t) {
     t.plan(3)
     var db = leveldown(testCommon.location())

--- a/abstract/chained-batch-test.js
+++ b/abstract/chained-batch-test.js
@@ -191,19 +191,6 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test serialize buffer', function (t) {
-    var batch = db.batch()
-    var ops = collectBatchOps(batch)
-
-    batch
-      .put(Buffer.from('foo'), Buffer.from('bar'))
-      .del(Buffer.from('baz'))
-    t.equal(ops[0].key.toString(), 'foo')
-    t.equal(ops[0].value.toString(), 'bar')
-    t.equal(ops[1].key.toString(), 'baz')
-    t.end()
-  })
-
   test('test custom _serialize*', function (t) {
     var _db = Object.create(db)
     _db._serializeKey = _db._serializeValue = function (data) { return data }

--- a/abstract/del-test.js
+++ b/abstract/del-test.js
@@ -41,18 +41,6 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test _serialize buffer', function (t) {
-    t.plan(2)
-    var db = leveldown(testCommon.location())
-    db._del = function (key, opts, callback) {
-      t.ok(Buffer.isBuffer(key))
-      callback()
-    }
-    db.del(Buffer.from('buf'), function (err, val) {
-      t.error(err)
-    })
-  })
-
   test('test custom _serialize*', function (t) {
     t.plan(2)
     var db = leveldown(testCommon.location())

--- a/abstract/get-test.js
+++ b/abstract/get-test.js
@@ -42,18 +42,6 @@ module.exports.args = function (test) {
     t.end()
   })
 
-  test('test _serialize buffer', function (t) {
-    t.plan(2)
-    var db = leveldown(testCommon.location())
-    db._get = function (key, opts, callback) {
-      t.same(key, Buffer.from('key'))
-      callback()
-    }
-    db.get(Buffer.from('key'), function (err, val) {
-      t.error(err)
-    })
-  })
-
   test('test custom _serialize*', function (t) {
     t.plan(2)
     var db = leveldown(testCommon.location())

--- a/abstract/put-test.js
+++ b/abstract/put-test.js
@@ -63,19 +63,6 @@ module.exports.args = function (test) {
     })
   })
 
-  test('test _serialize buffer', function (t) {
-    t.plan(3)
-    var db = leveldown(testCommon.location())
-    db._put = function (key, value, opts, callback) {
-      t.same(key, Buffer.from('key'))
-      t.same(value, Buffer.from('value'))
-      callback()
-    }
-    db.put(Buffer.from('key'), Buffer.from('value'), function (err, val) {
-      t.error(err)
-    })
-  })
-
   test('test custom _serialize*', function (t) {
     t.plan(3)
     var db = leveldown(testCommon.location())


### PR DESCRIPTION
These tests assert, for relevant methods like `_put`, that if the input is a Buffer, it is not touched.

However, this breaks an implementation like `localstorage-down` which cannot support Buffers natively, it has to convert Buffer keys and values to (base64) strings.

We don't need these tests (anymore) because for all the methods, we also have tests with a custom `_serializeKey` and/or `_serializeValue`. Which asserts that these methods do serialize. For example:

https://github.com/Level/abstract-leveldown/blob/49a1bd7156f3c476eda8f67e0f79946ce3674f3e/abstract/put-test.js#L79-L94

In addition, in the non-abstract test suite, we assert that the default `_serializeKey` and  `_serializeValue` leave Buffers alone:

https://github.com/Level/abstract-leveldown/blob/49a1bd7156f3c476eda8f67e0f79946ce3674f3e/test.js#L80

https://github.com/Level/abstract-leveldown/blob/49a1bd7156f3c476eda8f67e0f79946ce3674f3e/test.js#L89