### PR TITLE
add dont-break

### DIFF
--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,0 +1,4 @@
+[
+  "https://github.com/level/leveldown",
+  "https://github.com/level/memdown"
+]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * tests to make sure callbacks are called async (@vweevers)
 * tests for serialization extensibility (@vweevers)
 * @vweevers to contributors (@ralphtheninja)
+* `dont-break` to minimize dependent breakage (@ralphtheninja)
 
 ### Changed
 * `AbstractLevelDOWN#_setupIteratorOptions` ignores empty range options (@ralphtheninja)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "xtend": "~4.0.0"
   },
   "devDependencies": {
+    "dont-break": "^1.12.0",
     "rimraf": "^2.6.1",
     "sinon": "^4.0.0",
     "standard": "^10.0.3",
@@ -44,7 +45,8 @@
     "rimraf": false
   },
   "scripts": {
-    "test": "standard && node test.js"
+    "test": "standard && node test.js",
+    "dont-break": "dont-break"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Solves https://github.com/Level/abstract-leveldown/issues/184

Note that currently `dont-break` stops execution at first fail, so if `leveldown` fails there will be no feedback for subsequent dependents, in this case `memdown`.

But we could work on `dont-break` and make that happen instead of coming up with a completely new system for this.