### PR TITLE
Fix typings for Batch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ export interface AbstractIteratorOptions<K=any> {
   values?: boolean;
 }
 
-export type Batch<K=any, V?=any> = PutBatch<K, V> | DelBatch<K>
+export type Batch<K=any, V=any> = PutBatch<K, V> | DelBatch<K>
 
 export interface PutBatch<K=any, V=any> {
   type: 'put',

--- a/test.js
+++ b/test.js
@@ -230,6 +230,7 @@ test('test batch() extensibility', function (t) {
   var spy = sinon.spy()
   var expectedCb = function () {}
   var expectedOptions = { options: 1 }
+  /** @type {Array<{ type: 'put', key, value } | { type: 'del', key }>} */
   var expectedArray = [
     { type: 'put', key: '1', value: '1' },
     { type: 'del', key: '2' }
@@ -676,6 +677,7 @@ test('test serialization extensibility (batch array is not mutated)', function (
 
   test = new Test('foobar')
 
+  /** @type { { type: 'put', key, value } } */
   var op = { type: 'put', key: 'no', value: 'nope' }
   test.batch([op], function () {})
 


### PR DESCRIPTION
Tried using the typings with typescript 2.6/2.7 and neither worked. Both throw on `type Batch<K=any, V?=any>`. https://github.com/Level/abstract-leveldown/commit/b353fb45b00165222aa616111ddc8ae00e9a860a added the `?` before the default for some reason. AFAIK this is not valid typescript, and servers no purpose. Since `type Batch<K=any, V=any>` already has defaults, the values are optional. Without the question mark it seems to be working.

@vweevers can you elaborate on what you were trying to achieve?