### PR TITLE
Optional type parameter in index.d.ts:fix syntax

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ export interface AbstractIteratorOptions<K=any> {
   values?: boolean;
 }
 
-export type Batch<K=any, V?=any> = PutBatch<K, V> | DelBatch<K>
+export type Batch<K=any, V=any> = PutBatch<K, V> | DelBatch<K>
 
 export interface PutBatch<K=any, V=any> {
   type: 'put',


### PR DESCRIPTION
The type `Batch` in index.d.ts has an incorrect `?` following the name of the optional type parameter `V`. The type parameter is already implicitly optional because it has a default type `any`.

This question mark causes Typescript compilation errors. Removing it removes the errors.