### PR TITLE
Greenkeeper: ignore typescript dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,12 @@
   "license": "MIT",
   "engines": {
     "node": ">=4"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "@types/node",
+      "ts-node",
+      "typescript"
+    ]
   }
 }


### PR DESCRIPTION
To prevent PRs like #213, #214. Because of https://github.com/Level/community/issues/16.