### PR TITLE
Update upgrade guide [wip]

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,7 +15,7 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 `AbstractLevelDOWN` is no longer associated with a `location`. It's up to the implementation to handle it if it's required.
 
-If you previously did:
+If your implementation has a `location` and you previously did:
 
 ```js
 function YourDOWN (location) {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -55,16 +55,6 @@ You must now do:
 const testCommon = require('abstract-leveldown/test/common')
 ```
 
-### Abstract test suite API changed
-
-All `.all()` methods and sub tests now have identical function signatures, e.g.:
-
-```js
-exports.all = function (test, testCommon) {
-  // ..
-}
-```
-
 ### Default `testCommon` was rewritten to be unopinionated
 
 Now `testCommon` only implements two methods, `setUp` and `tearDown`, which became noops.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -134,6 +134,12 @@ If your implementation previously defined the public `iterator.seek(target)`, it
 
 Please see [README.md](README.md) for details.
 
+### Chained batch has been refactored
+
+- The default `_clear` method is no longer a noop; instead it clears the operations queued by `_put` and/or `_del`
+- The `_write` method now takes an `options` object as its first argument
+- The `db` argument in the constructor became mandatory, as well the `_db` property on the instance.
+
 ## v5
 
 Dropped support for node 4. No other breaking changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -144,7 +144,7 @@ Before this, the behavior of these types depended on a large number of factors: 
 
 ### Default `_serializeKey` and `_serializeValue` became identity functions
 
-They return whatever is given. Previously they were opinionated and mostly geared towards string- and Buffer-based storages. Implementations that didn't already define their own serialization should now do so, according to the types that they support. Please refer to the [README](README.md) for recommendations.
+They return whatever is given. Previously they were opinionated and mostly geared towards string- and Buffer-based storages. Implementations that didn't already define their own serialization should now do so, according to the types that they support. Please refer to the [README](README.md) for recommended behavior.
 
 ### Range options are serialized
 
@@ -152,12 +152,17 @@ Previously, range options like `lt` were passed through as-is, unlike keys.
 
 ### The rules for range options have been relaxed
 
-To support them being used as (encoded) lower and upper bounds, `null`, `undefined`, zero-length strings and zero-length buffers became valid as range options. In fact, any type is now valid. This means `db.iterator({ gt: undefined })` is *not* the same as `db.iterator({})`.
+Because `null`, `undefined`, zero-length strings and zero-length buffers are significant types in encodings like `bytewise` and `charwise`, they became valid as range options. In fact, any type is now valid. This means `db.iterator({ gt: undefined })` is not the same as `db.iterator({})`.
 
-### `_checkKey` does not coerce to string
-### Empty array keys are rejected
-### Remove range tests with null
-### No longer assumes that implementation supports boolean and `NaN` keys
+Furthermore, `abstract-leveldown` makes no assumptions about the meaning of these types. Range tests that assumed `null` meant "not defined" have been removed.
+
+### Zero-length array keys are rejected
+
+Though this was already the case because `_checkKey` stringified its input before checking the length, that behavior has been replaced with an explicit `Array.isArray()` check and a new error message.
+
+### No longer assumes support of boolean and `NaN` keys
+
+A test that asserted boolean and `NaN` keys were stringified has been removed.
 
 ## v5
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -75,6 +75,21 @@ require('abstract-leveldown/test')({
 })
 ```
 
+### The `collectEntries` utility has moved
+
+The `testCommon.collectEntries` method has moved to the npm package  `level-concat-iterator`. If your (additional) tests depend on `collectEntries` and you previously did:
+
+```js
+testCommon.collectEntries(iterator, function (err, entries) {})
+```
+
+You must now do:
+
+```js
+const concat = require('level-concat-iterator')
+concat(iterator, function (err, entries) {})
+```
+
 ### Setup and teardown have moved
 
 The `testCommon.setUp` and `testCommon.tearDown` methods have moved to test options. They are now noops by default:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -93,6 +93,10 @@ testCommon.factory = function () {
 abstract.all(test, testCommon)
 ```
 
+### Empty `errorValues()` test was removed
+
+If your implementation tests were calling this directly, simply remove usage.
+
 ## v5
 
 Dropped support for node 4. No other breaking changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -136,6 +136,29 @@ Please see [README.md](README.md) for details.
 - The `_write` method now takes an `options` object as its first argument
 - The `db` argument in the constructor became mandatory, as well the `_db` property on the instance.
 
+### Nullish values are rejected
+
+In addition to rejecting `null` and `undefined` as *keys*, `abstract-leveldown` now also rejects these types as *values*, due to preexisting significance in streams and iterators.
+
+Before this, the behavior of these types depended on a large number of factors: `_serializeValue` and type support of the underlying storage, whether `get()`, `iterator()` or a stream was used to retrieve values, the `keys` and `asBuffer` options of `iterator()` and finally, which encoding was selected.
+
+### Default `_serializeKey` and `_serializeValue` became identity functions
+
+They return whatever is given. Previously they were opinionated and mostly geared towards string- and Buffer-based storages. Implementations that didn't already define their own serialization should now do so, according to the types that they support. Please refer to the [README](README.md) for recommendations.
+
+### Range options are serialized
+
+Previously, range options like `lt` were passed through as-is, unlike keys.
+
+### The rules for range options have been relaxed
+
+To support them being used as (encoded) lower and upper bounds, `null`, `undefined`, zero-length strings and zero-length buffers became valid as range options. In fact, any type is now valid. This means `db.iterator({ gt: undefined })` is *not* the same as `db.iterator({})`.
+
+### `_checkKey` does not coerce to string
+### Empty array keys are rejected
+### Remove range tests with null
+### No longer assumes that implementation supports boolean and `NaN` keys
+
 ## v5
 
 Dropped support for node 4. No other breaking changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -75,9 +75,9 @@ This goes for *most* sub tests as well with the exception of `.setUp()` and `.ra
 
 Now `testCommon` only implements two methods, `setUp` and `tearDown`, which became noops.
 
-As part of removing `location`, the abstract tests no longer use `testCommon.location()`. Instead an implementation *must* implement `testCommon.factory()` which should return a unique database instance. This allows implementations to pass options to their constructor.
+As part of removing `location`, the abstract tests no longer use `testCommon.location()`. Instead an implementation *must* implement `testCommon.factory()` which *must* return a unique database instance. This allows implementations to pass options to their constructor.
 
-The `cleanup` method has been removed from `testCommon` and it's now up to implementations to handle this. The `lastLocation` method has also been removed as there is no remaining use of it in abstract tests.
+The `cleanup` method has been removed from `testCommon`. Because `testCommon.factory()` returns a unique database instance, cleanup should no longer be necessary. The `lastLocation` method has also been removed as there is no remaining use of it in abstract tests.
 
 Previously, implementations using the default `testCommon` had to include `rimraf` in their `devDependencies` and browser-based implementations had to exclude `rimraf` from browserify builds. This is no longer the case.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -194,7 +194,7 @@ Though this was already the case because `_checkKey` stringified its input befor
 
 ### No longer assumes support of boolean and `NaN` keys
 
-A test that asserted boolean and `NaN` keys were stringified has been removed.
+A test that asserted boolean and `NaN` keys were valid has been removed.
 
 ## v5
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,7 +27,7 @@ function YourDOWN (location) {
 
 ### Abstract test suite has moved to a single entry point
 
-With this move, `testCommon.js` is gone. If you previously did:
+With this move, `testCommon` is gone. If you previously did:
 
 ```js
 const test = require('tape')

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,10 +41,6 @@ require('abstract-leveldown/test/get-test')
 require('abstract-leveldown/test/put-test') // etc
 ```
 
-### Default `testCommon` is for disk-based, Node.js implementations only
-
-If your implementation or its target environment doesn't meet these criteria, you must implement a custom `testCommon`.
-
 ### Default `testCommon` has moved
 
 If you previously did:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -61,7 +61,7 @@ const testCommon = require('abstract-leveldown/test/common')
 
 ### Abstract test suite API changed
 
-All `.all()` methods now has the following signature:
+All `.all()` methods now have the following signature:
 
 ```js
 exports.all = function (test, testCommon) {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -81,7 +81,7 @@ The `cleanup` method has been removed from `testCommon`. Because `testCommon.fac
 
 Previously, implementations using the default `testCommon` had to include `rimraf` in their `devDependencies` and browser-based implementations had to exclude `rimraf` from browserify builds. This is no longer the case.
 
-If your implementation is location based we recommend using `tempy` (or similar) to create unique temporary directories. Together with `testCommon.factory()` your setup could now look something like:
+If your implementation is disk-based we recommend using `tempy` (or similar) to create unique temporary directories. Together with `testCommon.factory()` your setup could now look something like:
 
 ```js
 const test = require('tape')

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,13 @@
 
 This document describes breaking changes and how to upgrade. For a complete list of changes including minor and patch releases, please refer to the changelog.
 
+## Table of Contents
+
+- [Unreleased](#unreleased)
+- [v5](#v5)
+- [v4](#v4)
+- [v3](#v3)
+
 ## Unreleased
 
 ### `location` was removed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,6 +32,14 @@ function YourDOWN (location) {
 }
 ```
 
+Be sure to include appropriate type checks. If you relied on the default `AbstractLevelDOWN` behavior that would be:
+
+```js
+if (typeof location !== 'string') {
+  throw new Error('constructor requires a location string argument')
+}
+```
+
 ### Abstract test suite has moved to a single entry point
 
 With this move, `testCommon` is gone. If you previously did:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -75,7 +75,7 @@ This goes for *most* sub tests as well with the exception of `.setUp()` and `.ra
 
 Now `testCommon` only implements two methods, `setUp` and `tearDown`, which became noops.
 
-As part of removing `location`, the abstract tests no longer use `testCommon.location()`. Instead an implementation *must* implement `testCommon.factory()` which should return a fresh database instance. This allows implementations to pass options to their constructor.
+As part of removing `location`, the abstract tests no longer use `testCommon.location()`. Instead an implementation *must* implement `testCommon.factory()` which should return a unique database instance. This allows implementations to pass options to their constructor.
 
 The `cleanup` method has been removed from `testCommon` and it's now up to implementations to handle this. The `lastLocation` method has also been removed as there is no remaining use of it in abstract tests.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -61,7 +61,7 @@ const testCommon = require('abstract-leveldown/test/common')
 
 ### Abstract test suite API changed
 
-All `.all()` methods now has the the following signature:
+All `.all()` methods now has the following signature:
 
 ```js
 exports.all = function (test, testCommon) {

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -57,15 +57,13 @@ const testCommon = require('abstract-leveldown/test/common')
 
 ### Abstract test suite API changed
 
-All `.all()` methods now have the following signature:
+All `.all()` methods and sub tests now have identical function signatures, e.g.:
 
 ```js
 exports.all = function (test, testCommon) {
   // ..
 }
 ```
-
-This goes for *most* sub tests as well with the exception of `.setUp()` and `.range()` in `test/iterator-range-test.js` which accepts an additional `data` parameter.
 
 ### Default `testCommon` was rewritten to be unopinionated
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -121,10 +121,6 @@ require('abstract-leveldown/test')({
 })
 ```
 
-### Empty `errorValues()` test was removed
-
-If your implementation tests were calling this directly, simply remove usage.
-
 ### Seeking became part of official API
 
 If your implementation previously defined the public `iterator.seek(target)`, it must now define the private `iterator._seek(target)`. The new public API is equal to the reference implementation of `leveldown` except for two differences:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -97,6 +97,10 @@ abstract.all(test, testCommon)
 
 If your implementation tests were calling this directly, simply remove usage.
 
+### Deprecated `snapshot()` test was removed
+
+If your implementation tests were calling this directly, simply remove usage.
+
 ## v5
 
 Dropped support for node 4. No other breaking changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -110,6 +110,15 @@ require('abstract-leveldown/test')({
 
 If your implementation tests were calling this directly, simply remove usage.
 
+### Seeking became part of official API
+
+If your implementation previously defined the public `iterator.seek(target)`, it must now define the private `iterator._seek(target)`. The new public API is equal to the reference implementation of `leveldown` except for two differences:
+
+- The `target` argument is not type checked, this is up to the implementation.
+- The `target` argument is passed through `db._serializeKey`.
+
+Please see [README.md](README.md) for details.
+
 ## v5
 
 Dropped support for node 4. No other breaking changes.


### PR DESCRIPTION
I was thinking we could keep this branch alive and tweak the upgrade guide separately as we go. Then just squash it on top of everything, once we're done.