### PR TITLE
Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ End iteration and free up underlying resources. The `callback` function will be 
 
 ### Type Support
 
-The following applies to any method above that takes a `key` argument or option: all implementations *must* support a `key` of type String and *should* support a `key` of type Buffer. A `key` may not be `null`, `undefined`, a zero-length Buffer or zero-length string.
+The following applies to any method above that takes a `key` argument or option: all implementations *must* support a `key` of type String and *should* support a `key` of type Buffer. A `key` may not be `null`, `undefined`, a zero-length Buffer, zero-length string or zero-length array.
 
 The following applies to any method above that takes a `value` argument or option: all implementations *must* support a `value` of type String or Buffer. Values of type `null` and `undefined` are currently accepted but likely to be dropped in a next version.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ End iteration and free up underlying resources. The `callback` function will be 
 
 The following applies to any method above that takes a `key` argument or option: all implementations *must* support a `key` of type String and *should* support a `key` of type Buffer. A `key` may not be `null`, `undefined`, a zero-length Buffer, zero-length string or zero-length array.
 
-The following applies to any method above that takes a `value` argument or option: all implementations *must* support a `value` of type String or Buffer. Values of type `null` and `undefined` are currently accepted but likely to be dropped in a next version.
+The following applies to any method above that takes a `value` argument or option: all implementations *must* support a `value` of type String or Buffer. A `value` may not be `null` or `undefined` due to preexisting significance in streams and iterators.
 
 Support of other key and value types depends on the implementation as well as its underlying storage. See also [`db._serializeKey`](#private-serialize-key) and [`db._serializeValue`](#private-serialize-value).
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Legacy options:
 - `start`: instead use `gte`
 - `end`: instead use `lte`.
 
-By default, a range option that is either an empty buffer or an empty string will be ignored. Note that `null` and `undefined` are valid range options. An `abstract-leveldown` implementation is expected to either [*encode*][encoding-down] nullish, [*serialize*](#private-serialize-key) nullish, *delegate* to an underlying store, or finally, *ignore* nullish.
+Note that `null`, `undefined`, zero-length strings and zero-length buffers are invalid as keys, yet valid as range options. These types are commonly used as lower and upper bounds in encodings like `bytewise`. An `abstract-leveldown` implementation is expected to either [*encode*][encoding-down] these range option types, [*serialize*](#private-serialize-key) them, *delegate* to an underlying store, or finally, *ignore* them.
 
 In addition to range options, `iterator()` takes the following options:
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Legacy options:
 - `start`: instead use `gte`
 - `end`: instead use `lte`.
 
-By default, a range option that is either an empty buffer, an empty string, `null` or `undefined` will be ignored. Note that `null` and `undefined` are valid range options at a higher level. An `abstract-leveldown` implementation is expected to either [*encode*][encoding-down] nullish, [*serialize*](#private-serialize-key) nullish, *delegate* to an underlying store, or finally, *ignore* nullish.
+By default, a range option that is either an empty buffer or an empty string will be ignored. Note that `null` and `undefined` are valid range options. An `abstract-leveldown` implementation is expected to either [*encode*][encoding-down] nullish, [*serialize*](#private-serialize-key) nullish, *delegate* to an underlying store, or finally, *ignore* nullish.
 
 In addition to range options, `iterator()` takes the following options:
 

--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -17,8 +17,8 @@ AbstractChainedBatch.prototype._checkWritten = function () {
 AbstractChainedBatch.prototype.put = function (key, value) {
   this._checkWritten()
 
-  var err = this._db._checkKey(key, 'key')
-  if (err) { throw err }
+  var err = this._db._checkKey(key) || this._db._checkValue(value)
+  if (err) throw err
 
   key = this._db._serializeKey(key)
   value = this._db._serializeValue(value)
@@ -35,8 +35,8 @@ AbstractChainedBatch.prototype._put = function (key, value) {
 AbstractChainedBatch.prototype.del = function (key) {
   this._checkWritten()
 
-  var err = this._db._checkKey(key, 'key')
-  if (err) { throw err }
+  var err = this._db._checkKey(key)
+  if (err) throw err
 
   key = this._db._serializeKey(key)
   this._del(key)

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -226,6 +226,7 @@ AbstractLevelDOWN.prototype._chainedBatch = function () {
   return new AbstractChainedBatch(this)
 }
 
+// TODO: should we check for empty keys *after* serialization?
 AbstractLevelDOWN.prototype._serializeKey = function (key) {
   return key
 }
@@ -237,18 +238,14 @@ AbstractLevelDOWN.prototype._serializeValue = function (value) {
 AbstractLevelDOWN.prototype._checkKey = function (obj, type) {
   if (obj === null || obj === undefined) {
     return new Error(type + ' cannot be `null` or `undefined`')
-  }
-
-  if (Buffer.isBuffer(obj)) {
+  } else if (Buffer.isBuffer(obj)) {
     if (obj.length === 0) {
       return new Error(type + ' cannot be an empty Buffer')
     }
-
-    return
-  }
-
-  if (String(obj) === '') {
+  } else if (obj === '') {
     return new Error(type + ' cannot be an empty String')
+  } else if (Array.isArray(obj) && obj.length === 0) {
+    return new Error(type + ' cannot be an empty Array')
   }
 }
 

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -241,10 +241,8 @@ AbstractLevelDOWN.prototype._serializeValue = function (value) {
 AbstractLevelDOWN.prototype._checkKey = function (key) {
   if (key === null || key === undefined) {
     return new Error('key cannot be `null` or `undefined`')
-  } else if (Buffer.isBuffer(key)) {
-    if (key.length === 0) {
-      return new Error('key cannot be an empty Buffer')
-    }
+  } else if (Buffer.isBuffer(key) && key.length === 0) {
+    return new Error('key cannot be an empty Buffer')
   } else if (key === '') {
     return new Error('key cannot be an empty String')
   } else if (Array.isArray(key) && key.length === 0) {

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -175,7 +175,7 @@ AbstractLevelDOWN.prototype._batch = function (array, options, callback) {
 }
 
 AbstractLevelDOWN.prototype._setupIteratorOptions = function (options) {
-  options = cleanRangeOptions(options)
+  options = cleanRangeOptions(this, options)
 
   options.reverse = !!options.reverse
   options.keys = options.keys !== false
@@ -187,14 +187,23 @@ AbstractLevelDOWN.prototype._setupIteratorOptions = function (options) {
   return options
 }
 
-function cleanRangeOptions (options) {
+function cleanRangeOptions (db, options) {
   var result = {}
 
   for (var k in options) {
     if (!hasOwnProperty.call(options, k)) continue
-    if (isRangeOption(k) && isEmptyRangeOption(options[k])) continue
 
-    result[k] = options[k]
+    var opt = options[k]
+
+    if (isRangeOption(k)) {
+      if (isEmptyRangeOption(opt)) continue
+
+      // Note that we don't reject null and undefined here. While those
+      // types are invalid as keys, they are valid as range options.
+      opt = db._serializeKey(opt)
+    }
+
+    result[k] = opt
   }
 
   return result

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -174,6 +174,7 @@ AbstractLevelDOWN.prototype._batch = function (array, options, callback) {
   process.nextTick(callback)
 }
 
+// TODO: in encoding-down, we need a way to first encode, then serialize.
 AbstractLevelDOWN.prototype._setupIteratorOptions = function (options) {
   options = cleanRangeOptions(this, options)
 
@@ -196,10 +197,8 @@ function cleanRangeOptions (db, options) {
     var opt = options[k]
 
     if (isRangeOption(k)) {
-      if (isEmptyRangeOption(opt)) continue
-
-      // Note that we don't reject null and undefined here. While those
-      // types are invalid as keys, they are valid as range options.
+      // Note that we don't reject nullish and empty options here. While
+      // those types are invalid as keys, they are valid as range options.
       opt = db._serializeKey(opt)
     }
 
@@ -211,14 +210,6 @@ function cleanRangeOptions (db, options) {
 
 function isRangeOption (k) {
   return rangeOptions.indexOf(k) !== -1
-}
-
-function isEmptyRangeOption (v) {
-  return v === '' || isEmptyBuffer(v)
-}
-
-function isEmptyBuffer (v) {
-  return Buffer.isBuffer(v) && v.length === 0
 }
 
 AbstractLevelDOWN.prototype.iterator = function (options) {

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -205,7 +205,7 @@ function isRangeOption (k) {
 }
 
 function isEmptyRangeOption (v) {
-  return v === '' || v == null || isEmptyBuffer(v)
+  return v === '' || isEmptyBuffer(v)
 }
 
 function isEmptyBuffer (v) {

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -227,12 +227,11 @@ AbstractLevelDOWN.prototype._chainedBatch = function () {
 }
 
 AbstractLevelDOWN.prototype._serializeKey = function (key) {
-  return Buffer.isBuffer(key) ? key : String(key)
+  return key
 }
 
 AbstractLevelDOWN.prototype._serializeValue = function (value) {
-  if (value == null) return ''
-  return Buffer.isBuffer(value) || process.browser ? value : String(value)
+  return value
 }
 
 AbstractLevelDOWN.prototype._checkKey = function (obj, type) {

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -230,7 +230,6 @@ AbstractLevelDOWN.prototype._chainedBatch = function () {
   return new AbstractChainedBatch(this)
 }
 
-// TODO: should we check for empty keys *after* serialization?
 AbstractLevelDOWN.prototype._serializeKey = function (key) {
   return key
 }

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -239,8 +239,12 @@ AbstractLevelDOWN.prototype._checkKey = function (obj, type) {
     return new Error(type + ' cannot be `null` or `undefined`')
   }
 
-  if (Buffer.isBuffer(obj) && obj.length === 0) {
-    return new Error(type + ' cannot be an empty Buffer')
+  if (Buffer.isBuffer(obj)) {
+    if (obj.length === 0) {
+      return new Error(type + ' cannot be an empty Buffer')
+    }
+
+    return
   }
 
   if (String(obj) === '') {

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -174,7 +174,6 @@ AbstractLevelDOWN.prototype._batch = function (array, options, callback) {
   process.nextTick(callback)
 }
 
-// TODO: in encoding-down, we need a way to first encode, then serialize.
 AbstractLevelDOWN.prototype._setupIteratorOptions = function (options) {
   options = cleanRangeOptions(this, options)
 

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -66,6 +66,28 @@ exports.args = function (test, testCommon) {
     })
   })
 
+  test('test batch() with empty `key`', function (t) {
+    var illegalKeys = [
+      { type: 'String', key: '' },
+      { type: 'Buffer', key: Buffer.alloc(0) },
+      { type: 'Array', key: [] }
+    ]
+
+    t.plan(illegalKeys.length * 3)
+
+    illegalKeys.forEach(function (item) {
+      var async = false
+
+      db.batch([{ type: 'put', key: item.key, value: 'foo1' }], function (err) {
+        t.ok(err, 'got error')
+        t.equal(err.message, 'key cannot be an empty ' + item.type, 'correct error message')
+        t.ok(async, 'callback is asynchronous')
+      })
+
+      async = true
+    })
+  })
+
   test('test batch() with missing `key` and `value`', function (t) {
     var async = false
 

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -18,15 +18,20 @@ exports.args = function (test, testCommon) {
 
   test('test batch() with missing `value`', function (t) {
     db.batch([{ type: 'put', key: 'foo1' }], function (err) {
-      t.error(err)
+      t.is(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
       t.end()
     })
   })
 
-  test('test batch() with null `value`', function (t) {
-    db.batch([{ type: 'put', key: 'foo1', value: null }], function (err) {
-      t.error(err)
-      t.end()
+  test('test batch() with null or undefined `value`', function (t) {
+    var illegalValues = [null, undefined]
+
+    t.plan(illegalValues.length)
+
+    illegalValues.forEach(function (value) {
+      db.batch([{ type: 'put', key: 'foo1', value: value }], function (err) {
+        t.is(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
+      })
     })
   })
 

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -48,17 +48,22 @@ exports.args = function (test, testCommon) {
     async = true
   })
 
-  test('test batch() with null `key`', function (t) {
-    var async = false
+  test('test batch() with null or undefined `key`', function (t) {
+    var illegalKeys = [null, undefined]
 
-    db.batch([{ type: 'put', key: null, value: 'foo1' }], function (err) {
-      t.ok(err, 'got error')
-      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
-      t.ok(async, 'callback is asynchronous')
-      t.end()
+    t.plan(illegalKeys.length * 3)
+
+    illegalKeys.forEach(function (key) {
+      var async = false
+
+      db.batch([{ type: 'put', key: key, value: 'foo1' }], function (err) {
+        t.ok(err, 'got error')
+        t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
+        t.ok(async, 'callback is asynchronous')
+      })
+
+      async = true
     })
-
-    async = true
   })
 
   test('test batch() with missing `key` and `value`', function (t) {

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -95,6 +95,19 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
+  test('test batch#put() with null or undefined `value`', function (t) {
+    var illegalValues = [null, undefined]
+    t.plan(illegalValues.length)
+
+    illegalValues.forEach(function (value) {
+      try {
+        db.batch().put('key', value)
+      } catch (err) {
+        t.equal(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
+      }
+    })
+  })
+
   test('test batch#del() with missing `key`', function (t) {
     try {
       db.batch().del()

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -106,15 +106,17 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test batch#del() with null `key`', function (t) {
-    try {
-      db.batch().del(null)
-    } catch (err) {
-      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
-      return t.end()
-    }
-    t.fail('should have thrown')
-    t.end()
+  test('test batch#del() with null or undefined `key`', function (t) {
+    var illegalKeys = [null, undefined]
+    t.plan(illegalKeys.length)
+
+    illegalKeys.forEach(function (key) {
+      try {
+        db.batch().del(key)
+      } catch (err) {
+        t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
+      }
+    })
   })
 
   test('test batch#clear() doesn\'t throw', function (t) {

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -117,17 +117,6 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test batch#del() with null `key`', function (t) {
-    try {
-      db.batch().del(null)
-    } catch (err) {
-      t.equal(err.message, 'key cannot be `null` or `undefined`', 'correct error message')
-      return t.end()
-    }
-    t.fail('should have thrown')
-    t.end()
-  })
-
   test('test batch#clear() doesn\'t throw', function (t) {
     db.batch().clear()
     t.end()

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -39,13 +39,27 @@ exports.args = function (test, testCommon) {
   })
 
   test('test batch#put() with missing `value`', function (t) {
-    db.batch().put('foo1')
-    t.end()
+    t.plan(1)
+
+    try {
+      db.batch().put('foo1')
+    } catch (err) {
+      t.is(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
+    }
   })
 
-  test('test batch#put() with null `value`', function (t) {
-    db.batch().put('foo1', null)
-    t.end()
+  test('test batch#put() with null or undefined `value`', function (t) {
+    var illegalValues = [null, undefined]
+
+    t.plan(illegalValues.length)
+
+    illegalValues.forEach(function (value) {
+      try {
+        db.batch().put('foo1', value)
+      } catch (err) {
+        t.is(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
+      }
+    })
   })
 
   test('test batch#put() with missing `key`', function (t) {

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -48,20 +48,6 @@ exports.args = function (test, testCommon) {
     }
   })
 
-  test('test batch#put() with null or undefined `value`', function (t) {
-    var illegalValues = [null, undefined]
-
-    t.plan(illegalValues.length)
-
-    illegalValues.forEach(function (value) {
-      try {
-        db.batch().put('foo1', value)
-      } catch (err) {
-        t.is(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
-      }
-    })
-  })
-
   test('test batch#put() with missing `key`', function (t) {
     try {
       db.batch().put(undefined, 'foo1')
@@ -103,7 +89,7 @@ exports.args = function (test, testCommon) {
       try {
         db.batch().put('key', value)
       } catch (err) {
-        t.equal(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
+        t.is(err.message, 'value cannot be `null` or `undefined`', 'correct error message')
       }
     })
   })

--- a/test/iterator-range-test.js
+++ b/test/iterator-range-test.js
@@ -337,16 +337,6 @@ exports.range = function (test, testCommon) {
     start: ''
   }, data)
 
-  // TODO: should we remove this? The behavior depends on
-  // implementation-specific serialization and encoding.
-  // rangeTest('test iterator with gte as null', {
-  //   gte: null
-  // }, data)
-  //
-  // rangeTest('test iterator with start as null - legacy', {
-  //   start: null
-  // }, data)
-
   rangeTest('test iterator with lte as empty string', {
     lte: ''
   }, data)
@@ -354,16 +344,6 @@ exports.range = function (test, testCommon) {
   rangeTest('test iterator with end as empty string - legacy', {
     end: ''
   }, data)
-
-  // TODO: should we remove this? The behavior depends on
-  // implementation-specific serialization and encoding.
-  // rangeTest('test iterator with lte as null', {
-  //   lte: null
-  // }, data)
-  //
-  // rangeTest('test iterator with end as null - legacy', {
-  //   end: null
-  // }, data)
 }
 
 exports.tearDown = function (test, testCommon) {

--- a/test/iterator-range-test.js
+++ b/test/iterator-range-test.js
@@ -337,13 +337,15 @@ exports.range = function (test, testCommon) {
     start: ''
   }, data)
 
-  rangeTest('test iterator with gte as null', {
-    gte: null
-  }, data)
-
-  rangeTest('test iterator with start as null - legacy', {
-    start: null
-  }, data)
+  // TODO: should we remove this? The behavior depends on
+  // implementation-specific serialization and encoding.
+  // rangeTest('test iterator with gte as null', {
+  //   gte: null
+  // }, data)
+  //
+  // rangeTest('test iterator with start as null - legacy', {
+  //   start: null
+  // }, data)
 
   rangeTest('test iterator with lte as empty string', {
     lte: ''
@@ -353,13 +355,15 @@ exports.range = function (test, testCommon) {
     end: ''
   }, data)
 
-  rangeTest('test iterator with lte as null', {
-    lte: null
-  }, data)
-
-  rangeTest('test iterator with end as null - legacy', {
-    end: null
-  }, data)
+  // TODO: should we remove this? The behavior depends on
+  // implementation-specific serialization and encoding.
+  // rangeTest('test iterator with lte as null', {
+  //   lte: null
+  // }, data)
+  //
+  // rangeTest('test iterator with end as null - legacy', {
+  //   end: null
+  // }, data)
 }
 
 exports.tearDown = function (test, testCommon) {

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -117,7 +117,7 @@ exports.nonErrorKeys = function (test, testCommon) {
   makePutGetDelSuccessfulTest(
     test
     , 'long String key'
-    , 'some long string that I\'m using as a key for this unit test, cross your fingers dude, we\'re going in!'
+    , 'some long string that I\'m using as a key for this unit test, cross your fingers human, we\'re going in!'
     , 'foo'
   )
 
@@ -148,7 +148,7 @@ exports.nonErrorValues = function (test, testCommon) {
     test
     , 'long String value'
     , 'foo'
-    , 'some long string that I\'m using as a key for this unit test, cross your fingers dude, we\'re going in!'
+    , 'some long string that I\'m using as a key for this unit test, cross your fingers human, we\'re going in!'
   )
 
   // standard Buffer value

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -114,9 +114,7 @@ exports.errorValues = function (test, testCommon) {
 
 exports.nonErrorKeys = function (test, testCommon) {
   // valid falsey keys
-  makePutGetDelSuccessfulTest(test, '`false` key', false, 'foo false')
   makePutGetDelSuccessfulTest(test, '`0` key', 0, 'foo 0')
-  makePutGetDelSuccessfulTest(test, '`NaN` key', NaN, 'foo NaN')
 
   // standard String key
   makePutGetDelSuccessfulTest(

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -142,6 +142,8 @@ exports.nonErrorValues = function (test, testCommon) {
   // all of the following result in an empty-string value:
   makePutGetDelSuccessfulTest(test, 'empty String value', 'foo', '', '')
   makePutGetDelSuccessfulTest(test, 'empty Buffer value', 'foo', Buffer.alloc(0), '')
+
+  // note that an implementation may return the value as an array
   makePutGetDelSuccessfulTest(test, 'empty Array value', 'foo', [], '')
 
   // standard String value

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -104,7 +104,7 @@ exports.errorKeys = function (test, testCommon) {
   makeErrorKeyTest(test, 'undefined key', undefined, /key cannot be `null` or `undefined`/)
   makeErrorKeyTest(test, 'empty String key', '', /key cannot be an empty String/)
   makeErrorKeyTest(test, 'empty Buffer key', Buffer.alloc(0), /key cannot be an empty \w*Buffer/)
-  makeErrorKeyTest(test, 'empty Array key', [], /key cannot be an empty String/)
+  makeErrorKeyTest(test, 'empty Array key', [], /key cannot be an empty Array/)
 }
 
 exports.nonErrorKeys = function (test, testCommon) {

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -107,6 +107,11 @@ exports.errorKeys = function (test, testCommon) {
   makeErrorKeyTest(test, 'empty Array key', [], /key cannot be an empty Array/)
 }
 
+exports.errorValues = function (test, testCommon) {
+  makePutErrorTest(test, 'null value', 'key', null, /value cannot be `null` or `undefined`/)
+  makePutErrorTest(test, 'undefined value', 'key', undefined, /value cannot be `null` or `undefined`/)
+}
+
 exports.nonErrorKeys = function (test, testCommon) {
   // valid falsey keys
   makePutGetDelSuccessfulTest(test, '`false` key', false, 'foo false')
@@ -137,8 +142,6 @@ exports.nonErrorValues = function (test, testCommon) {
   makePutGetDelSuccessfulTest(test, '`NaN` value', 'foo NaN', NaN)
 
   // all of the following result in an empty-string value:
-  makePutGetDelSuccessfulTest(test, '`null` value', 'foo null', null, '')
-  makePutGetDelSuccessfulTest(test, '`undefined` value', 'foo undefined', undefined, '')
   makePutGetDelSuccessfulTest(test, 'empty String value', 'foo', '', '')
   makePutGetDelSuccessfulTest(test, 'empty Buffer value', 'foo', Buffer.alloc(0), '')
   makePutGetDelSuccessfulTest(test, 'empty Array value', 'foo', [], '')
@@ -167,6 +170,7 @@ exports.tearDown = function (test, testCommon) {
 exports.all = function (test, testCommon) {
   exports.setUp(test, testCommon)
   exports.errorKeys(test, testCommon)
+  exports.errorValues(test, testCommon)
   exports.nonErrorKeys(test, testCommon)
   exports.nonErrorValues(test, testCommon)
   exports.tearDown(test, testCommon)

--- a/test/self.js
+++ b/test/self.js
@@ -816,9 +816,9 @@ test('_setupIteratorOptions', function (t) {
     return options
   }
 
-  function verifyUndefinedOptions (t, options) {
+  function verifyOptions (t, options) {
     keys.forEach(function (key) {
-      t.notOk(key in options, 'property should be deleted')
+      t.ok(key in options, 'property should not be deleted')
     })
     t.end()
   }
@@ -854,21 +854,37 @@ test('_setupIteratorOptions', function (t) {
     t.end()
   })
 
-  t.test('deletes empty buffers', function (t) {
+  t.test('does not delete empty buffers', function (t) {
     var options = setupOptions(function () { return Buffer.from('') })
     keys.forEach(function (key) {
       t.is(Buffer.isBuffer(options[key]), true, 'should be buffer')
       t.is(options[key].length, 0, 'should be empty')
     })
-    verifyUndefinedOptions(t, db._setupIteratorOptions(options))
+    verifyOptions(t, db._setupIteratorOptions(options))
   })
 
-  t.test('deletes empty strings', function (t) {
+  t.test('does not delete empty strings', function (t) {
     var options = setupOptions(function () { return '' })
     keys.forEach(function (key) {
       t.is(typeof options[key], 'string', 'should be string')
       t.is(options[key].length, 0, 'should be empty')
     })
-    verifyUndefinedOptions(t, db._setupIteratorOptions(options))
+    verifyOptions(t, db._setupIteratorOptions(options))
+  })
+
+  t.test('does not delete null', function (t) {
+    var options = setupOptions(function () { return null })
+    keys.forEach(function (key) {
+      t.is(options[key], null, 'should be null')
+    })
+    verifyOptions(t, db._setupIteratorOptions(options))
+  })
+
+  t.test('does not delete undefined', function (t) {
+    var options = setupOptions(function () { return undefined })
+    keys.forEach(function (key) {
+      t.is(options[key], undefined, 'should be undefined')
+    })
+    verifyOptions(t, db._setupIteratorOptions(options))
   })
 })

--- a/test/self.js
+++ b/test/self.js
@@ -855,12 +855,4 @@ test('_setupIteratorOptions', function (t) {
     })
     verifyUndefinedOptions(t, db._setupIteratorOptions(options))
   })
-
-  t.test('deletes null options', function (t) {
-    var options = setupOptions(function () { return null })
-    keys.forEach(function (key) {
-      t.same(options[key], null, 'should be null')
-    })
-    verifyUndefinedOptions(t, db._setupIteratorOptions(options))
-  })
 })

--- a/test/self.js
+++ b/test/self.js
@@ -662,6 +662,35 @@ test('test serialization extensibility (batch array is not mutated)', function (
   t.equal(op.value, 'nope', 'did not mutate input value')
 })
 
+test('test serialization extensibility (iterator range options)', function (t) {
+  t.plan(2)
+
+  function Test () {
+    AbstractLevelDOWN.call(this)
+  }
+
+  inherits(Test, AbstractLevelDOWN)
+
+  Test.prototype._serializeKey = function (key) {
+    t.is(key, 'input')
+    return 'output'
+  }
+
+  Test.prototype._iterator = function (options) {
+    return new Iterator(this, options)
+  }
+
+  function Iterator (db, options) {
+    AbstractIterator.call(this, db)
+    t.is(options.gt, 'output')
+  }
+
+  inherits(Iterator, AbstractIterator)
+
+  var test = new Test()
+  test.iterator({ gt: 'input' })
+})
+
 test('test serialization extensibility (iterator seek)', function (t) {
   t.plan(3)
 

--- a/test/self.js
+++ b/test/self.js
@@ -92,25 +92,12 @@ test('test core extensibility', function (t) {
 
 test('test key/value serialization', function (t) {
   var Test = implement(AbstractLevelDOWN)
-  var buffer = Buffer.alloc(0)
-  var test = new Test('foobar')
+  var test = new Test()
 
-  t.equal(test._serializeKey(1), '1', '_serializeKey converts to string')
-  t.ok(test._serializeKey(buffer) === buffer, '_serializeKey returns Buffer as is')
-
-  t.equal(test._serializeValue(null), '', '_serializeValue converts null to empty string')
-  t.equal(test._serializeValue(undefined), '', '_serializeValue converts undefined to empty string')
-
-  var browser = !!process.browser
-  process.browser = false
-
-  t.equal(test._serializeValue(1), '1', '_serializeValue converts to string')
-  t.ok(test._serializeValue(buffer) === buffer, '_serializeValue returns Buffer as is')
-
-  process.browser = true
-  t.equal(test._serializeValue(1), 1, '_serializeValue returns value as is when process.browser')
-
-  process.browser = browser
+  ;['', {}, null, undefined, Buffer.alloc(0)].forEach(function (v) {
+    t.ok(test._serializeKey(v) === v, '_serializeKey is an identity function')
+    t.ok(test._serializeValue(v) === v, '_serializeValue is an identity function')
+  })
 
   t.end()
 })


### PR DESCRIPTION
Closes #120, closes #130, closes #230. Checklist adapted from https://github.com/Level/abstract-leveldown/issues/120#issuecomment-390171073:

- [x] Don't touch nullish range options in `abstract#_setupIteratorOptions` (no need for #222)
- [x] Don't touch empty range options in `abstract#_setupIteratorOptions`. ~~TBD~~
- [x] Change `_serializeKey` to an identity function
- [x] Change `_serializeValue` to an identity function
- [x] ~~Reject nullish keys *before* calling `_serializeKey`.~~ (Already the case). The benefit is that `_serializeKey` can be used on range options with nullish support.
- [x] Reject nullish values *before* calling `_serializeValue`
- [x] ~~Reject nullish and empty keys *after* calling `_serializeKey`? TBD~~
- [x] ~~Reject nullish values *after* calling `_serializeValue`? TBD~~
- [x] Pass range options through `_serializeKey` (#130)
- [x] Remove boolean and NaN key tests

These are very tricky changes, will need canary testing in at least `leveldown`.

Externally (just mental notes):

- Add `leveldown#_serializeKey` and `#_serializeValue` (same logic) to convert nullish to an empty string, Buffer as-is, everything else to a string.