### PR TITLE
Add 'bufferKeys' and 'seek' to skip options

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Close the store. If closing failed, call the `callback` function with an `Error`
 <a name="private-serialize-key"></a>
 ### `db._serializeKey(key)`
 
-Convert a `key` to a type supported by the underlying storage. All methods below that take a `key` argument or option will receive serialized keys. For example, if `_serializeKey` is implemented as:
+Convert a `key` to a type supported by the underlying storage. All methods below that take a `key` argument or option - as well as `_seek(target)` - will receive serialized keys. For example, if `_serializeKey` is implemented as:
 
 ```js
 FakeLevelDOWN.prototype._serializeKey = function (key) {
@@ -428,6 +428,8 @@ suite({
 
 This also serves as a signal to users of your implementation. The following options are available:
 
+- `bufferKeys`: set to `false` if binary keys are not supported by the underlying storage
+- `seek`: set to `false` if your `iterator` does not implement `_seek`
 - `snapshots`: set to `false` if any of the following is true:
   - Reads don't operate on a [snapshot](#public-iterator)
   - Snapshots are created asynchronously

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -151,7 +151,7 @@ suite({
 })
 ```
 
-Please see the [README](README.md) for a list of options.
+Please see the [README](README.md) for a list of options. Note that some of these have replaced `process.browser` checks.
 
 ### Seeking became part of official API
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -142,16 +142,16 @@ suite({
 
 ### Optional tests have been separated
 
-If your implementation does not support snapshots, or the `createIfMissing` and `errorIfExists` options to `db.open`, the relevant tests may be skipped. To skip all three:
+If your implementation does not support snapshots or other optional features, the relevant tests may be skipped. For example:
 
 ```js
 suite({
   // ..
-  snapshots: false,
-  createIfMissing: false,
-  errorIfExists: false
+  snapshots: false
 })
 ```
+
+Please see the [README](README.md) for a list of options.
 
 ### Seeking became part of official API
 
@@ -160,7 +160,7 @@ If your implementation previously defined the public `iterator.seek(target)`, it
 - The `target` argument is not type checked, this is up to the implementation.
 - The `target` argument is passed through `db._serializeKey`.
 
-Please see [README.md](README.md) for details.
+Please see the [README](README.md) for details.
 
 ### Chained batch has been refactored
 

--- a/test/common.js
+++ b/test/common.js
@@ -15,9 +15,11 @@ function testCommon (options) {
     factory: factory,
     setUp: options.setUp || noopTest(),
     tearDown: options.tearDown || noopTest(),
+    bufferKeys: options.bufferKeys !== false,
     createIfMissing: options.createIfMissing !== false,
     errorIfExists: options.errorIfExists !== false,
-    snapshots: options.snapshots !== false
+    snapshots: options.snapshots !== false,
+    seek: options.seek !== false
   }
 }
 

--- a/test/iterator-range-test.js
+++ b/test/iterator-range-test.js
@@ -310,8 +310,7 @@ exports.range = function (test, testCommon) {
     reverse: true
   }, [])
 
-  if (!process.browser) {
-    // Can't use buffers as query keys in indexeddb (I think :P)
+  if (testCommon.bufferKeys) {
     rangeTest('test iterator with gte as empty buffer', {
       gte: Buffer.alloc(0)
     }, data)

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -124,8 +124,7 @@ exports.nonErrorKeys = function (test, testCommon) {
     , 'foo'
   )
 
-  if (!process.browser) {
-    // Buffer key
+  if (testCommon.bufferKeys) {
     makePutGetDelSuccessfulTest(test, 'Buffer key', testBuffer, 'foo')
   }
 


### PR DESCRIPTION
Closes #287 and I also added a `seek` option in anticipation of #269.

Tested against `leveldown` (to see that it ran the same number of tests).

With this, `process.browser` is gone! ~~But before we close #121 I wanna go through it, possibly open new issues for related stuff like https://github.com/Level/abstract-leveldown/issues/121#issuecomment-343722989.~~ *(done)*