### PR TITLE
Remove range tests that assumed zero-length strings or Buffers meant "not defined"

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,11 +186,13 @@ Legacy options:
 - `start`: instead use `gte`
 - `end`: instead use `lte`.
 
-**Note** Zero-length strings, buffers and arrays as well as `null` and `undefined` are invalid as keys, yet valid as range options. These types are significant in encodings like [`bytewise`](https://github.com/deanlandolt/bytewise) and [`charwise`](https://github.com/dominictarr/charwise). Consumers of an implementation should assume that `{ gt: undefined }` is _not_ the same as `{}`. An implementation can choose to:
+**Note** Zero-length strings, buffers and arrays as well as `null` and `undefined` are invalid as keys, yet valid as range options. These types are significant in encodings like [`bytewise`](https://github.com/deanlandolt/bytewise) and [`charwise`](https://github.com/dominictarr/charwise) as well as some underlying stores like IndexedDB. Consumers of an implementation should assume that `{ gt: undefined }` is _not_ the same as `{}`. An implementation can choose to:
 
 - [_Serialize_](#db_serializekeykey) or [_encode_][encoding-down] these types to make them meaningful
 - Have no defined behavior (moving the concern to a higher level)
 - Delegate to an underlying store (moving the concern to a lower level).
+
+If you are an implementor, a final note: the [abstract test suite](#test-suite) does not test these types. Whether they are supported or how they sort is up to you; add custom tests accordingly.
 
 In addition to range options, `iterator()` takes the following options:
 

--- a/test/iterator-range-test.js
+++ b/test/iterator-range-test.js
@@ -309,40 +309,6 @@ exports.range = function (test, testCommon) {
     end: '9a',
     reverse: true
   }, [])
-
-  if (testCommon.bufferKeys) {
-    rangeTest('test iterator with gte as empty buffer', {
-      gte: Buffer.alloc(0)
-    }, data)
-
-    rangeTest('test iterator with start as empty buffer - legacy', {
-      start: Buffer.alloc(0)
-    }, data)
-
-    rangeTest('test iterator with lte as empty buffer', {
-      lte: Buffer.alloc(0)
-    }, data)
-
-    rangeTest('test iterator with end as empty buffer - legacy', {
-      end: Buffer.alloc(0)
-    }, data)
-  }
-
-  rangeTest('test iterator with gte as empty string', {
-    gte: ''
-  }, data)
-
-  rangeTest('test iterator with start as empty string - legacy', {
-    start: ''
-  }, data)
-
-  rangeTest('test iterator with lte as empty string', {
-    lte: ''
-  }, data)
-
-  rangeTest('test iterator with end as empty string - legacy', {
-    end: ''
-  }, data)
 }
 
 exports.tearDown = function (test, testCommon) {


### PR DESCRIPTION
Can be released as semver-patch, if you are OK with the plan outlined in https://github.com/Level/abstract-leveldown/issues/318 (I'll close that one after having opened follow-up issues on relevant repos).