### PR TITLE
Fix and test asynchronicity of empty batch

### DIFF
--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -142,6 +142,10 @@ AbstractLevelDOWN.prototype.batch = function (array, options, callback) {
     return process.nextTick(callback, new Error('batch(array) requires an array argument'))
   }
 
+  if (array.length === 0) {
+    return process.nextTick(callback)
+  }
+
   if (typeof options !== 'object' || options === null) options = {}
 
   var serialized = new Array(array.length)

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -193,16 +193,21 @@ exports.args = function (test, testCommon) {
       async = true
     })
   })
+
+  test('test batch() with empty array', function (t) {
+    var async = false
+
+    db.batch([], function (err) {
+      t.error(err, 'no error from batch()')
+      t.ok(async, 'callback is asynchronous')
+      t.end()
+    })
+
+    async = true
+  })
 }
 
 exports.batch = function (test, testCommon) {
-  test('test batch() with empty array', function (t) {
-    db.batch([], function (err) {
-      t.error(err)
-      t.end()
-    })
-  })
-
   test('test simple batch()', function (t) {
     db.batch([{ type: 'put', key: 'foo', value: 'bar' }], function (err) {
       t.error(err)

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -233,6 +233,18 @@ exports.args = function (test, testCommon) {
       { type: 'del', key: 'key2' }
     ])
   })
+
+  test('test batch#write() with no operations', function (t) {
+    var async = false
+
+    db.batch().write(function (err) {
+      t.ifError(err, 'no error from write()')
+      t.ok(async, 'callback is asynchronous')
+      t.end()
+    })
+
+    async = true
+  })
 }
 
 exports.batch = function (test, testCommon) {

--- a/test/self.js
+++ b/test/self.js
@@ -232,7 +232,7 @@ test('test put() extensibility', function (t) {
   t.end()
 })
 
-test('test batch() extensibility', function (t) {
+test('test batch([]) (array-form) extensibility', function (t) {
   var spy = sinon.spy()
   var expectedCb = function () {}
   var expectedOptions = { options: 1 }
@@ -272,7 +272,25 @@ test('test batch() extensibility', function (t) {
   t.end()
 })
 
-test('test chained batch() (array) extensibility', function (t) {
+test('test batch([]) (array-form) with empty array is asynchronous', function (t) {
+  var spy = sinon.spy()
+  var Test = implement(AbstractLevelDOWN, { _batch: spy })
+  var test = new Test()
+  var async = false
+
+  test.batch([], function (err) {
+    t.ifError(err, 'no error')
+    t.ok(async, 'callback is asynchronous')
+
+    // Assert that asynchronicity is provided by batch() rather than _batch()
+    t.is(spy.callCount, 0, '_batch() call was bypassed')
+    t.end()
+  })
+
+  async = true
+})
+
+test('test chained batch() extensibility', function (t) {
   var spy = sinon.spy()
   var expectedCb = function () {}
   var expectedOptions = { options: 1 }
@@ -302,6 +320,20 @@ test('test chained batch() (array) extensibility', function (t) {
   t.equal(spy.getCall(1).args[2], expectedCb, 'got expected callback argument')
 
   t.end()
+})
+
+test('test chained batch() with no operations is asynchronous', function (t) {
+  var Test = implement(AbstractLevelDOWN, {})
+  var test = new Test()
+  var async = false
+
+  test.batch().write(function (err) {
+    t.ifError(err, 'no error')
+    t.ok(async, 'callback is asynchronous')
+    t.end()
+  })
+
+  async = true
 })
 
 test('test chained batch() (custom _chainedBatch) extensibility', function (t) {


### PR DESCRIPTION
Closes #336.

- `db.batch([], callback)` now calls `callback` asynchronously, bypassing `_batch()`
- I considered doing the same for chained batch, by tracking if the batch has operations, but decided not to, so that implementations can choose to ignore certain operations. For example, `batch.del(0)` might be ignored and `abstract-leveldown` would wrongly think there's a queued operation.
- Added abstract tests for asynchronicity of `db.batch([])` (array-form) and `db.batch()` (chained-form)