### PR TITLE
Proof of concept: asyncIterator

### DIFF
--- a/test/async-iterator-test.js
+++ b/test/async-iterator-test.js
@@ -1,0 +1,78 @@
+'use strict'
+
+// This file is excluded from the abstract test suite atm
+
+const test = require('tape')
+const AbstractLevelDOWN = require('..').AbstractLevelDOWN
+const AbstractIterator = require('..').AbstractIterator
+
+class MockDown extends AbstractLevelDOWN {
+  _iterator (options) {
+    return new MockIterator(this, options)
+  }
+}
+
+class MockIterator extends AbstractIterator {
+  constructor (db, options) {
+    super(db)
+    this.input = options.input.slice()
+  }
+
+  _next (callback) {
+    process.nextTick(callback, null, this.input.shift(), this.input.shift())
+  }
+}
+
+test('for await...of db.iterator()', async function (t) {
+  t.plan(2)
+
+  const db = new MockDown()
+  const input = ['key1', 'value1', 'key2', 'value2']
+  const output = []
+  const it = db.iterator({ input })
+
+  for await (let [key, value] of it) {
+    output.push(key, value)
+  }
+
+  t.ok(it._ended, 'ended')
+  t.same(output, input)
+})
+
+test('for await...of db.iterator() ends on user error', async function (t) {
+  t.plan(2)
+
+  const db = new MockDown()
+  const input = ['key1', 'value1']
+  const it = db.iterator({ input })
+
+  try {
+    // eslint-disable-next-line no-unused-vars
+    for await (let kv of it) {
+      throw new Error('user error')
+    }
+  } catch (err) {
+    t.is(err.message, 'user error')
+    t.ok(it._ended, 'ended')
+  }
+})
+
+test('for await...of db.iterator() ends on iterator error', async function (t) {
+  t.plan(2)
+
+  const db = new MockDown()
+  const input = ['key1', 'value1']
+  const it = db.iterator({ input })
+
+  it._next = function (callback) {
+    process.nextTick(callback, new Error('iterator error'))
+  }
+
+  try {
+    // eslint-disable-next-line no-unused-vars
+    for await (let kv of it) {}
+  } catch (err) {
+    t.is(err.message, 'iterator error')
+    t.ok(it._ended, 'ended')
+  }
+})


### PR DESCRIPTION
_Do not merge. Ignore failing tests._

This is to find out what we need to support [`Symbol.asyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) in userland (we cannot do it here because we need async generators to properly handle ending on errors, and async generators are only available in Node 10+ and Chrome).

The answer is that we need to add Promise support to `iterator.next()` and `.end()`. We can do that in the same way as `levelup`: if you don't provide a callback argument, you get back a Promise.

This means there will be three ways to iterate:

1. callbacks
2. `async/await` (a bit awkward)

```js
const it = db.iterator()
const kv = await it.next()

if (!kv) {
  await it.end()
} else {
  const [key, value] = kv
}
```

3. `for await...of`

```js
for await (let [key, value] of db.iterator()) {
  // no need to call end
}
```

cc @chjj @peakji 

---

Previous discussions:

- https://github.com/Level/abstract-leveldown/issues/235
- https://github.com/Level/leveldown/pull/601
- https://github.com/Level/leveldown/issues/627