### PR TITLE
src: Import buffer

### DIFF
--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -1,5 +1,6 @@
 var xtend = require('xtend')
 var supports = require('level-supports')
+var Buffer = require('buffer').Buffer
 var AbstractIterator = require('./abstract-iterator')
 var AbstractChainedBatch = require('./abstract-chained-batch')
 var hasOwnProperty = Object.prototype.hasOwnProperty


### PR DESCRIPTION
Do not rely on the global.Buffer property implicitly.

In some environments like `electron` this global variable
does not exist at all.