### PR TITLE
src: move level-concat-iterator to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "prepublishOnly": "npm run dependency-check"
   },
   "dependencies": {
-    "level-concat-iterator": "~2.0.0",
     "level-supports": "~1.0.0",
     "xtend": "~4.0.0"
   },
@@ -24,6 +23,7 @@
     "dependency-check": "^3.3.0",
     "hallmark": "^2.0.0",
     "level-community": "^3.0.0",
+    "level-concat-iterator": "~2.0.0",
     "nyc": "^14.0.0",
     "sinon": "^7.2.4",
     "standard": "^14.0.0",


### PR DESCRIPTION
The level-concat-iterator dependency is not used by any
of the production code, it's a utility library used in the test
suite and should be marked as a devDependencies.

cc @vweevers 