### PR TITLE
Support running test suite on a levelup db

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ This also serves as a signal to users of your implementation. The following opti
   - Reads don't operate on a [snapshot](#iterator)
   - Snapshots are created asynchronously
 - `createIfMissing` and `errorIfExists`: set to `false` if `db._open()` does not support these options.
+- `legacyRange`: set to `false` if your iterator does not support the legacy `start` and `end` range options.
 
 This metadata will be moved to manifests (`db.supports`) in the future.
 

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -11,7 +11,7 @@ exports.setUp = function (test, testCommon) {
 }
 
 exports.args = function (test, testCommon) {
-  test('test callback-less, 2-arg, batch() throws', function (t) {
+  testCommon.promises || test('test callback-less, 2-arg, batch() throws', function (t) {
     t.throws(
       db.batch.bind(db, 'foo', {}),
       /Error: batch\(array\) requires a callback argument/,
@@ -215,7 +215,11 @@ exports.batch = function (test, testCommon) {
       db.get('foo', function (err, value) {
         t.error(err)
         var result
-        if (isTypedArray(value)) {
+
+        if (testCommon.encodings) {
+          t.is(typeof value, 'string')
+          result = value
+        } else if (isTypedArray(value)) {
           result = String.fromCharCode.apply(null, new Uint16Array(value))
         } else {
           t.ok(typeof Buffer !== 'undefined' && value instanceof Buffer)
@@ -244,7 +248,10 @@ exports.batch = function (test, testCommon) {
       db.get('foobatch1', function (err, value) {
         t.error(err)
         var result
-        if (isTypedArray(value)) {
+        if (testCommon.encodings) {
+          t.is(typeof value, 'string')
+          result = value
+        } else if (isTypedArray(value)) {
           result = String.fromCharCode.apply(null, new Uint16Array(value))
         } else {
           t.ok(typeof Buffer !== 'undefined' && value instanceof Buffer)
@@ -264,7 +271,10 @@ exports.batch = function (test, testCommon) {
       db.get('foobatch3', function (err, value) {
         t.error(err)
         var result
-        if (isTypedArray(value)) {
+        if (testCommon.encodings) {
+          t.is(typeof value, 'string')
+          result = value
+        } else if (isTypedArray(value)) {
           result = String.fromCharCode.apply(null, new Uint16Array(value))
         } else {
           t.ok(typeof Buffer !== 'undefined' && value instanceof Buffer)

--- a/test/chained-batch-test.js
+++ b/test/chained-batch-test.js
@@ -123,7 +123,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test batch#write() with no callback', function (t) {
+  testCommon.promises || test('test batch#write() with no callback', function (t) {
     try {
       db.batch().write()
     } catch (err) {
@@ -186,7 +186,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test serialize object', function (t) {
+  testCommon.serialize && test('test serialize object', function (t) {
     var batch = db.batch()
     var ops = collectBatchOps(batch)
 
@@ -202,7 +202,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test custom _serialize*', function (t) {
+  testCommon.serialize && test('test custom _serialize*', function (t) {
     t.plan(4)
 
     var _db = Object.create(db)

--- a/test/clear-test.js
+++ b/test/clear-test.js
@@ -10,7 +10,7 @@ exports.setUp = function (test, testCommon) {
 }
 
 exports.args = function (test, testCommon) {
-  test('test argument-less clear() throws', function (t) {
+  testCommon.promises || test('test argument-less clear() throws', function (t) {
     t.throws(
       db.clear.bind(db),
       /Error: clear\(\) requires a callback argument/,

--- a/test/close-test.js
+++ b/test/close-test.js
@@ -10,12 +10,12 @@ exports.setUp = function (test, testCommon) {
 
 exports.close = function (test, testCommon) {
   test('test close()', function (t) {
-    t.throws(
+    testCommon.promises || t.throws(
       db.close.bind(db),
       /Error: close\(\) requires a callback argument/,
       'no-arg close() throws'
     )
-    t.throws(
+    testCommon.promises || t.throws(
       db.close.bind(db, 'foo'),
       /Error: close\(\) requires a callback argument/,
       'non-callback close() throws'

--- a/test/common.js
+++ b/test/common.js
@@ -24,7 +24,25 @@ function testCommon (options) {
     errorIfExists: options.errorIfExists !== false,
     snapshots: options.snapshots !== false,
     seek: options.seek !== false,
-    clear: !!options.clear
+    clear: !!options.clear,
+
+    // Allow skipping 'start' and 'end' tests
+    // TODO (next major): drop legacy range options
+    legacyRange: options.legacyRange !== false,
+
+    // Support running test suite on a levelup db. All options below this line
+    // are undocumented and should not be used by abstract-leveldown db's (yet).
+    promises: !!options.promises,
+    status: options.status !== false,
+    serialize: options.serialize !== false,
+
+    // If true, the test suite assumes a default encoding of utf8 (like levelup)
+    // and that operations return strings rather than buffers by default.
+    encodings: !!options.encodings,
+
+    // Not yet used, only here for symmetry with levelup's test suite.
+    deferredOpen: !!options.deferredOpen,
+    streams: !!options.streams
   }
 }
 

--- a/test/del-test.js
+++ b/test/del-test.js
@@ -10,7 +10,7 @@ exports.setUp = function (test, testCommon) {
 }
 
 exports.args = function (test, testCommon) {
-  test('test argument-less del() throws', function (t) {
+  testCommon.promises || test('test argument-less del() throws', function (t) {
     t.throws(
       db.del.bind(db),
       /Error: del\(\) requires a callback argument/,
@@ -19,7 +19,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test callback-less, 1-arg, del() throws', function (t) {
+  testCommon.promises || test('test callback-less, 1-arg, del() throws', function (t) {
     t.throws(
       db.del.bind(db, 'foo'),
       /Error: del\(\) requires a callback argument/,
@@ -28,7 +28,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test callback-less, 3-arg, del() throws', function (t) {
+  testCommon.promises || test('test callback-less, 3-arg, del() throws', function (t) {
     t.throws(
       db.del.bind(db, 'foo', {}),
       /Error: del\(\) requires a callback argument/,
@@ -37,7 +37,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test custom _serialize*', function (t) {
+  testCommon.serialize && test('test custom _serialize*', function (t) {
     t.plan(3)
     var db = testCommon.factory()
     db._serializeKey = function (data) { return data }

--- a/test/iterator-range-test.js
+++ b/test/iterator-range-test.js
@@ -35,6 +35,10 @@ exports.setUp = function (test, testCommon) {
 
 exports.range = function (test, testCommon) {
   function rangeTest (name, opts, expected) {
+    if (!testCommon.legacyRange && ('start' in opts || 'end' in opts)) {
+      return
+    }
+
     opts.keyAsBuffer = false
     opts.valueAsBuffer = false
     test(name, function (t) {

--- a/test/manifest-test.js
+++ b/test/manifest-test.js
@@ -5,7 +5,7 @@ module.exports = function (test, testCommon) {
 
   suite(test, testCommon)
 
-  test('manifest has status', function (t) {
+  testCommon.status && test('manifest has status', function (t) {
     var db = testCommon.factory()
     t.is(db.supports.status, true)
 

--- a/test/open-test.js
+++ b/test/open-test.js
@@ -3,7 +3,7 @@ exports.setUp = function (test, testCommon) {
 }
 
 exports.args = function (test, testCommon) {
-  test('test database open no-arg throws', function (t) {
+  testCommon.promises || test('test database open no-arg throws', function (t) {
     var db = testCommon.factory()
     t.throws(
       db.open.bind(db),
@@ -13,7 +13,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test callback-less, 1-arg, open() throws', function (t) {
+  testCommon.promises || test('test callback-less, 1-arg, open() throws', function (t) {
     var db = testCommon.factory()
     t.throws(
       db.open.bind(db, {}),

--- a/test/put-get-del-test.js
+++ b/test/put-get-del-test.js
@@ -50,15 +50,22 @@ function makePutErrorTest (test, type, key, value, expectedError) {
   })
 }
 
-function makePutGetDelSuccessfulTest (test, type, key, value, expectedResult) {
-  var hasExpectedResult = arguments.length === 5
+function makePutGetDelSuccessfulTest (test, testCommon, type, key, value, expectedResult) {
+  var hasExpectedResult = arguments.length === 6
   test('test put()/get()/del() with ' + type, function (t) {
     db.put(key, value, function (err) {
       t.error(err)
       db.get(key, function (err, _value) {
         t.error(err, 'no error, has key/value for `' + type + '`')
-        t.ok(Buffer.isBuffer(_value), 'is a Buffer')
-        var result = _value
+
+        if (!testCommon.encodings) {
+          t.ok(Buffer.isBuffer(_value), 'is a Buffer')
+          var result = _value
+        } else {
+          t.is(typeof _value, 'string', 'is a string')
+          result = _value
+        }
+
         if (hasExpectedResult) {
           t.equal(result.toString(), expectedResult)
         } else {
@@ -114,50 +121,52 @@ exports.errorValues = function (test, testCommon) {
 
 exports.nonErrorKeys = function (test, testCommon) {
   // valid falsey keys
-  makePutGetDelSuccessfulTest(test, '`0` key', 0, 'foo 0')
+  makePutGetDelSuccessfulTest(test, testCommon, '`0` key', 0, 'foo 0')
 
   // standard String key
   makePutGetDelSuccessfulTest(
     test
+    , testCommon
     , 'long String key'
     , 'some long string that I\'m using as a key for this unit test, cross your fingers human, we\'re going in!'
     , 'foo'
   )
 
   if (testCommon.bufferKeys) {
-    makePutGetDelSuccessfulTest(test, 'Buffer key', testBuffer, 'foo')
+    makePutGetDelSuccessfulTest(test, testCommon, 'Buffer key', testBuffer, 'foo')
   }
 
   // non-empty Array as a value
-  makePutGetDelSuccessfulTest(test, 'Array value', 'foo', [1, 2, 3, 4])
+  makePutGetDelSuccessfulTest(test, testCommon, 'Array value', 'foo', [1, 2, 3, 4])
 }
 
 exports.nonErrorValues = function (test, testCommon) {
   // valid falsey values
-  makePutGetDelSuccessfulTest(test, '`false` value', 'foo false', false)
-  makePutGetDelSuccessfulTest(test, '`0` value', 'foo 0', 0)
-  makePutGetDelSuccessfulTest(test, '`NaN` value', 'foo NaN', NaN)
+  makePutGetDelSuccessfulTest(test, testCommon, '`false` value', 'foo false', false)
+  makePutGetDelSuccessfulTest(test, testCommon, '`0` value', 'foo 0', 0)
+  makePutGetDelSuccessfulTest(test, testCommon, '`NaN` value', 'foo NaN', NaN)
 
   // all of the following result in an empty-string value:
-  makePutGetDelSuccessfulTest(test, 'empty String value', 'foo', '', '')
-  makePutGetDelSuccessfulTest(test, 'empty Buffer value', 'foo', Buffer.alloc(0), '')
+  makePutGetDelSuccessfulTest(test, testCommon, 'empty String value', 'foo', '', '')
+  makePutGetDelSuccessfulTest(test, testCommon, 'empty Buffer value', 'foo', Buffer.alloc(0), '')
 
   // note that an implementation may return the value as an array
-  makePutGetDelSuccessfulTest(test, 'empty Array value', 'foo', [], '')
+  makePutGetDelSuccessfulTest(test, testCommon, 'empty Array value', 'foo', [], '')
 
   // standard String value
   makePutGetDelSuccessfulTest(
     test
+    , testCommon
     , 'long String value'
     , 'foo'
     , 'some long string that I\'m using as a key for this unit test, cross your fingers human, we\'re going in!'
   )
 
   // standard Buffer value
-  makePutGetDelSuccessfulTest(test, 'Buffer value', 'foo', testBuffer)
+  makePutGetDelSuccessfulTest(test, testCommon, 'Buffer value', 'foo', testBuffer)
 
   // non-empty Array as a key
-  makePutGetDelSuccessfulTest(test, 'Array key', [1, 2, 3, 4], 'foo')
+  makePutGetDelSuccessfulTest(test, testCommon, 'Array key', [1, 2, 3, 4], 'foo')
 }
 
 exports.tearDown = function (test, testCommon) {

--- a/test/put-test.js
+++ b/test/put-test.js
@@ -10,7 +10,7 @@ exports.setUp = function (test, testCommon) {
 }
 
 exports.args = function (test, testCommon) {
-  test('test argument-less put() throws', function (t) {
+  testCommon.promises || test('test argument-less put() throws', function (t) {
     t.throws(
       db.put.bind(db),
       /Error: put\(\) requires a callback argument/,
@@ -19,7 +19,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test callback-less, 1-arg, put() throws', function (t) {
+  testCommon.promises || test('test callback-less, 1-arg, put() throws', function (t) {
     t.throws(
       db.put.bind(db, 'foo'),
       /Error: put\(\) requires a callback argument/,
@@ -28,7 +28,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test callback-less, 2-arg, put() throws', function (t) {
+  testCommon.promises || test('test callback-less, 2-arg, put() throws', function (t) {
     t.throws(
       db.put.bind(db, 'foo', 'bar'),
       /Error: put\(\) requires a callback argument/,
@@ -37,7 +37,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test callback-less, 3-arg, put() throws', function (t) {
+  testCommon.promises || test('test callback-less, 3-arg, put() throws', function (t) {
     t.throws(
       db.put.bind(db, 'foo', 'bar', {}),
       /Error: put\(\) requires a callback argument/,
@@ -46,7 +46,7 @@ exports.args = function (test, testCommon) {
     t.end()
   })
 
-  test('test _serialize object', function (t) {
+  testCommon.serialize && test('test _serialize object', function (t) {
     t.plan(3)
     var db = testCommon.factory()
     db._put = function (key, value, opts, callback) {
@@ -59,7 +59,7 @@ exports.args = function (test, testCommon) {
     })
   })
 
-  test('test custom _serialize*', function (t) {
+  testCommon.serialize && test('test custom _serialize*', function (t) {
     t.plan(4)
     var db = testCommon.factory()
     db._serializeKey = db._serializeValue = function (data) { return data }


### PR DESCRIPTION
As well as skipping 'start' and 'end' tests (for `multileveldown`) (see also https://github.com/Level/community/issues/86).

Doesn't change anything for existing `abstract-leveldown` implementations. Before releasing I do want to test it on:

- [x] `multileveldown` (as a `levelup` instance)
- [x] `subleveldown` (same)
- [x] `level`

Working towards https://github.com/Level/community/issues/58.