### PR TITLE
src: Allow buffer / nextTick to be overwritten

### DIFF
--- a/abstract-chained-batch.js
+++ b/abstract-chained-batch.js
@@ -1,5 +1,3 @@
-var nextTick = require('./next-tick')
-
 function AbstractChainedBatch (db) {
   if (typeof db !== 'object' || db === null) {
     throw new TypeError('First argument must be an abstract-leveldown compliant store')
@@ -79,8 +77,5 @@ AbstractChainedBatch.prototype.write = function (options, callback) {
 AbstractChainedBatch.prototype._write = function (options, callback) {
   this.db._batch(this._operations, options, callback)
 }
-
-// Expose browser-compatible nextTick for dependents
-AbstractChainedBatch.prototype._nextTick = nextTick
 
 module.exports = AbstractChainedBatch

--- a/abstract-iterator.js
+++ b/abstract-iterator.js
@@ -1,5 +1,3 @@
-var nextTick = require('./next-tick')
-
 function AbstractIterator (db) {
   if (typeof db !== 'object' || db === null) {
     throw new TypeError('First argument must be an abstract-leveldown compliant store')
@@ -18,12 +16,12 @@ AbstractIterator.prototype.next = function (callback) {
   }
 
   if (self._ended) {
-    nextTick(callback, new Error('cannot call next() after end()'))
+    this._nextTick(callback, new Error('cannot call next() after end()'))
     return self
   }
 
   if (self._nexting) {
-    nextTick(callback, new Error('cannot call next() before previous next() has completed'))
+    this._nextTick(callback, new Error('cannot call next() before previous next() has completed'))
     return self
   }
 
@@ -37,7 +35,7 @@ AbstractIterator.prototype.next = function (callback) {
 }
 
 AbstractIterator.prototype._next = function (callback) {
-  nextTick(callback)
+  this._nextTick(callback)
 }
 
 AbstractIterator.prototype.seek = function (target) {
@@ -60,7 +58,7 @@ AbstractIterator.prototype.end = function (callback) {
   }
 
   if (this._ended) {
-    return nextTick(callback, new Error('end() already called on iterator'))
+    return this._nextTick(callback, new Error('end() already called on iterator'))
   }
 
   this._ended = true
@@ -68,10 +66,12 @@ AbstractIterator.prototype.end = function (callback) {
 }
 
 AbstractIterator.prototype._end = function (callback) {
-  nextTick(callback)
+  this._nextTick(callback)
 }
 
 // Expose browser-compatible nextTick for dependents
-AbstractIterator.prototype._nextTick = nextTick
+AbstractIterator.prototype._nextTick = function (callback, value) {
+  process.nextTick(callback, value)
+}
 
 module.exports = AbstractIterator

--- a/abstract-leveldown.js
+++ b/abstract-leveldown.js
@@ -324,8 +324,8 @@ AbstractLevelDOWN.prototype._checkValue = function (value) {
 }
 
 // Expose browser-compatible nextTick for dependents
-AbstractLevelDOWN.prototype._nextTick = function (callback) {
-  process.nextTick(callback)
+AbstractLevelDOWN.prototype._nextTick = function (callback, value) {
+  process.nextTick(callback, value)
 }
 
 module.exports = AbstractLevelDOWN

--- a/next-tick-browser.js
+++ b/next-tick-browser.js
@@ -1,1 +1,0 @@
-module.exports = require('immediate')

--- a/next-tick.js
+++ b/next-tick.js
@@ -1,1 +1,0 @@
-module.exports = process.nextTick

--- a/package.json
+++ b/package.json
@@ -17,11 +17,8 @@
     "prepublishOnly": "npm run dependency-check"
   },
   "dependencies": {
-    "buffer": "^5.5.0",
-    "immediate": "^3.2.3",
     "level-concat-iterator": "~2.0.0",
-    "level-supports": "~1.0.0",
-    "xtend": "~4.0.0"
+    "level-supports": "~1.0.0"
   },
   "devDependencies": {
     "airtap": "^3.0.0",


### PR DESCRIPTION
There were two dependencies added. Buffer and immediate.

This is for browser support. Instead allow references to Buffer
and nextTick to be overwritten by the sub class.

This allows the browser module level-js to import these modules
and overwrite the methods using them.

Also in this PR inline xtend and remove it as a dependency.