### PR TITLE
tests: Move level-concat-iterator to optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   "dependencies": {
     "buffer": "^5.5.0",
     "immediate": "^3.2.3",
-    "level-concat-iterator": "~2.0.0",
     "level-supports": "~1.0.0",
     "xtend": "~4.0.0"
+  },
+  "optionalDependencies": {
+    "level-concat-iterator": "~2.0.0"
   },
   "devDependencies": {
     "airtap": "^3.0.0",

--- a/test/common.js
+++ b/test/common.js
@@ -1,3 +1,16 @@
+try {
+  require('level-concat-iterator')
+} catch (err) {
+  console.error('To use the abstract-leveldown test suite you must')
+  console.error('import level-concat-iterator as a dependency')
+  console.error('')
+  console.error('Please run `npm i level-concat-iterator@2 -D`')
+
+  throw new Error(
+    'level-concat-iterator is an optional dependency of the test suite.'
+  )
+}
+
 function testCommon (options) {
   var factory = options.factory
   var test = options.test


### PR DESCRIPTION
This means that it's only required for testing and not
a production dependency.

I've added a human readable error with instructions on how
to fix it for the users of this package.