### PR TITLE
chore: update deps

### DIFF
--- a/.airtap.yml
+++ b/.airtap.yml
@@ -2,8 +2,6 @@ browsers:
   - name: chrome
     version: latest
     platform: Windows 10
-  - name: internet explorer
-    version: '11'
   - name: firefox
     version: latest
     platform: Windows 10

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublishOnly": "npm run dependency-check"
   },
   "dependencies": {
-    "buffer": "^5.5.0",
+    "buffer": "^6.0.3",
     "immediate": "^3.2.3",
     "level-concat-iterator": "~2.0.0",
     "level-supports": "~1.0.0",


### PR DESCRIPTION
Updates `Buffer` to the latest version as having multiple versions in
the dep tree causes quite a lot of bundle bloat when run in browsers!