### PR TITLE
feat: map method with default _map fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ Store a new entry or overwrite an existing entry. There are no `options` by defa
 
 Delete an entry. There are no `options` by default but implementations may add theirs. The `callback` function will be called with no arguments if the operation is successful or with an `Error` if deletion failed for any reason.
 
+### `db.map(keys[, options], callback)`
+
+Get multiple values from the store by an array `keys`. The optional `options` object may contain:
+
+- `asBuffer` _(boolean, default: `true`)_: Whether to return each `value` in the result array as a Buffer. If `false`, the returned type depends on the implementation.
+
+The `callback` function will be called with an `Error` if the operation failed for any reason. If successful the first argument will be `null` and the second argument will be the array of values. Given N keys, the result will contain N values.
+
 ### `db.batch(operations[, options], callback)`
 
 Perform multiple _put_ and/or _del_ operations in bulk. The `operations` argument must be an `Array` containing a list of operations to be executed sequentially, although as a whole they are performed as an atomic operation.
@@ -426,6 +434,14 @@ The default `_put()` invokes `callback` on a next tick. It must be overridden.
 Delete an entry. There are no default options but `options` will always be an object. If deletion failed, call the `callback` function with an `Error`. Otherwise call `callback` without any arguments.
 
 The default `_del()` invokes `callback` on a next tick. It must be overridden.
+
+### `db._map(keys, options, callback)`
+
+Map each `key` in the `keys` array to a `value`. The `options` object will always have the following properties: `asBuffer`. If _any_ key in `keys` does not exist, call the `callback` function with a `new Error('NotFound')`. Otherwise call `callback` with `null` as the first argument and the values array as the second.
+
+The default `_map()` loops through each key in the array `keys` and invokes `_get(key)`. It invokes `callback` on the next tick with the concatenated `_get` results array. 
+
+If applicable it is _recommended_, but not required, to implement `_map()` as native-code as this will likely be more performant than the default fallback. 
 
 ### `db._batch(operations, options, callback)`
 

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,7 @@ function suite (options) {
   require('./get-test').all(test, testCommon)
   require('./del-test').all(test, testCommon)
   require('./put-get-del-test').all(test, testCommon)
+  require('./map-test').all(test, testCommon)
 
   require('./batch-test').all(test, testCommon)
   require('./chained-batch-test').all(test, testCommon)

--- a/test/map-test.js
+++ b/test/map-test.js
@@ -1,0 +1,197 @@
+'use strict'
+
+const verifyNotFoundError = require('./util').verifyNotFoundError
+const isTypedArray = require('./util').isTypedArray
+
+let db
+
+exports.setUp = function (test, testCommon) {
+  test('setUp common', testCommon.setUp)
+  test('setUp db', function (t) {
+    db = testCommon.factory()
+    db.open(t.end.bind(t))
+  })
+}
+
+exports.args = function (test, testCommon) {
+  testCommon.promises || test('test argument-less map() throws', function (t) {
+    t.throws(
+      db.map.bind(db),
+      /Error: map\(\) requires a callback argument/,
+      'no-arg map() throws'
+    )
+    t.end()
+  })
+
+  testCommon.promises || test('test callback-less, 1-arg, map() throws', function (t) {
+    t.throws(
+      db.map.bind(db, 'foo'),
+      /Error: map\(\) requires a callback argument/,
+      'callback-less, 1-arg map() throws'
+    )
+    t.end()
+  })
+
+  testCommon.promises || test('test callback-less, 3-arg, map() throws', function (t) {
+    t.throws(
+      db.map.bind(db, 'foo', {}),
+      /Error: map\(\) requires a callback argument/,
+      'callback-less, 2-arg map() throws'
+    )
+    t.end()
+  })
+
+  testCommon.serialize && test('test custom _serialize*', function (t) {
+    t.plan(3)
+    const db = testCommon.factory()
+    db._serializeKey = function (data) { return data }
+    db._map = function (keys, options, callback) {
+      t.deepEqual(keys, [{ foo: 'bar' }])
+      this._nextTick(callback)
+    }
+    db.open(function () {
+      db.map([{ foo: 'bar' }], function (err) {
+        t.error(err)
+        db.close(t.error.bind(t))
+      })
+    })
+  })
+}
+
+exports.map = function (test, testCommon) {
+  test('test simple map()', function (t) {
+    db.put('foo', 'bar', function (err) {
+      t.error(err)
+      db.put('ray', 'tay', function (err) {
+        t.error(err)
+        db.map(['foo', 'ray'], function (err, value) {
+          t.error(err)
+
+          let result
+
+          t.ok(Array.isArray(value), 'value should be an array')
+
+          if (!testCommon.encodings) {
+            t.ok(typeof value[0] !== 'string' && typeof value[1] !== 'string', 'should not be string by default')
+
+            result = value.forEah((x) => {
+              if (isTypedArray(x)) {
+                return String.fromCharCode.apply(null, new Uint16Array(x))
+              } else {
+                t.ok(typeof Buffer !== 'undefined' && x instanceof Buffer)
+                try {
+                  return x.toString()
+                } catch (e) {
+                  t.error(e, 'should not throw when converting value to a string')
+                }
+              }
+            })
+          } else {
+            result = value
+          }
+
+          t.deepEqual(result, ['bar', 'tay'])
+
+          db.map(['foo', 'ray'], {}, function (err, value) { // same but with {}
+            t.error(err)
+
+            let result
+
+            t.ok(Array.isArray(value), 'value should be an array')
+
+            if (!testCommon.encodings) {
+              t.ok(typeof value[0] !== 'string' && typeof value[1] !== 'string', 'should not be string by default')
+
+              result = value.map(function (x) {
+                if (isTypedArray(x)) {
+                  return String.fromCharCode.apply(null, new Uint16Array(x))
+                } else {
+                  t.ok(typeof Buffer !== 'undefined' && x instanceof Buffer)
+                  try {
+                    return x.toString()
+                  } catch (e) {
+                    t.error(e, 'should not throw when converting value to a string')
+                  }
+                }
+                return x
+              })
+            } else {
+              result = value
+            }
+
+            t.deepEqual(result, ['bar', 'tay'])
+
+            db.map(['foo', 'ray'], { asBuffer: false }, function (err, value) {
+              t.error(err)
+              t.ok(Array.isArray(value), 'value should be an array')
+              t.ok(typeof value === 'string', 'should be string if not buffer')
+              t.deepEqual(value, ['bar', 'tay'])
+              t.end()
+            })
+          })
+        })
+      })
+    })
+  })
+
+  test('test simultaniously map()', function (t) {
+    db.put('hello', 'world', function (err) {
+      t.error(err)
+      let r = 0
+      const done = function () {
+        if (++r === 20) { t.end() }
+      }
+      let i = 0
+      let j = 0
+
+      for (; i < 10; ++i) {
+        db.map(['hello'], function (err, value) {
+          t.error(err)
+          t.deepEqual(value.map(x => x.toString()), ['world'])
+          done()
+        })
+      }
+
+      for (; j < 10; ++j) {
+        db.map(['not found'], function (err, value) {
+          t.ok(err, 'should error')
+          t.ok(verifyNotFoundError(err), 'should have correct error message')
+          t.ok(typeof value === 'undefined', 'value is undefined')
+          done()
+        })
+      }
+    })
+  })
+
+  test('test map() not found error is asynchronous', function (t) {
+    t.plan(5)
+
+    db.put('hello', 'world', function (err) {
+      t.error(err)
+
+      let async = false
+
+      db.map(['not found'], function (err, value) {
+        t.ok(err, 'should error')
+        t.ok(verifyNotFoundError(err), 'should have correct error message')
+        t.ok(typeof value === 'undefined', 'value is undefined')
+        t.ok(async, 'callback is asynchronous')
+      })
+
+      async = true
+    })
+  })
+}
+
+exports.tearDown = function (test, testCommon) {
+  test('tearDown', function (t) {
+    db.close(testCommon.tearDown.bind(null, t))
+  })
+}
+
+exports.all = function (test, testCommon) {
+  exports.setUp(test, testCommon)
+  exports.args(test, testCommon)
+  exports.map(test, testCommon)
+  exports.tearDown(test, testCommon)
+}


### PR DESCRIPTION
As per https://github.com/Level/community/issues/100

Adds new `map` method to serve as a "multi-get" / "batch-get" method for implementing 'downs. 

Adds protected overload-able `_map` method with default fallback to looping over each key and using `_get`. i.e. non-breaking for non-implementing 'downs. 

