### PR TITLE
Support `for await...of db.iterator()`

### DIFF
--- a/test/async-iterator-test.js
+++ b/test/async-iterator-test.js
@@ -1,0 +1,203 @@
+'use strict'
+
+const input = [{ key: '1', value: '1' }, { key: '2', value: '2' }]
+
+let db
+
+exports.setup = function (test, testCommon) {
+  test('setup', function (t) {
+    t.plan(2)
+
+    db = testCommon.factory()
+    db.open(function (err) {
+      t.ifError(err, 'no open() error')
+
+      db.batch(input.map(entry => ({ ...entry, type: 'put' })), function (err) {
+        t.ifError(err, 'no batch() error')
+      })
+    })
+  })
+}
+
+exports.asyncIterator = function (test, testCommon) {
+  test('for await...of db.iterator()', async function (t) {
+    t.plan(2)
+
+    const it = db.iterator()
+    const output = []
+
+    for await (const [key, value] of it) {
+      output.push({ key, value })
+    }
+
+    t.ok(it._ended, 'ended')
+    t.same(output, input)
+  })
+
+  test('for await...of db.iterator() does not permit reuse', async function (t) {
+    t.plan(3)
+
+    const it = db.iterator()
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const [key, value] of it) {
+      t.pass('nexted')
+    }
+
+    try {
+      // eslint-disable-next-line no-unused-vars
+      for await (const [key, value] of it) {
+        t.fail('should not be called')
+      }
+    } catch (err) {
+      t.is(err.message, 'cannot call next() after end()')
+    }
+  })
+
+  test('for await...of db.iterator() ends on user error', async function (t) {
+    t.plan(2)
+
+    const it = db.iterator()
+
+    try {
+      // eslint-disable-next-line no-unused-vars, no-unreachable-loop
+      for await (const kv of it) {
+        throw new Error('user error')
+      }
+    } catch (err) {
+      t.is(err.message, 'user error')
+      t.ok(it._ended, 'ended')
+    }
+  })
+
+  test('for await...of db.iterator() with user error and end() error', async function (t) {
+    t.plan(3)
+
+    const it = db.iterator()
+    const end = it._end
+
+    it._end = function (callback) {
+      end.call(this, function (err) {
+        t.ifError(err, 'no real error from end()')
+        callback(new Error('end error'))
+      })
+    }
+
+    try {
+      // eslint-disable-next-line no-unused-vars, no-unreachable-loop
+      for await (const kv of it) {
+        throw new Error('user error')
+      }
+    } catch (err) {
+      // TODO: ideally, this would be a combined aka aggregate error
+      t.is(err.message, 'user error')
+      t.ok(it._ended, 'ended')
+    }
+  })
+
+  test('for await...of db.iterator() ends on iterator error', async function (t) {
+    t.plan(3)
+
+    const it = db.iterator()
+
+    it._next = function (callback) {
+      t.pass('nexted')
+      this._nextTick(callback, new Error('iterator error'))
+    }
+
+    try {
+      // eslint-disable-next-line no-unused-vars
+      for await (const kv of it) {
+        t.fail('should not yield results')
+      }
+    } catch (err) {
+      t.is(err.message, 'iterator error')
+      t.ok(it._ended, 'ended')
+    }
+  })
+
+  test('for await...of db.iterator() with iterator error and end() error', async function (t) {
+    t.plan(4)
+
+    const it = db.iterator()
+    const end = it._end
+
+    it._next = function (callback) {
+      t.pass('nexted')
+      this._nextTick(callback, new Error('iterator error'))
+    }
+
+    it._end = function (callback) {
+      end.call(this, function (err) {
+        t.ifError(err, 'no real error from end()')
+        callback(new Error('end error'))
+      })
+    }
+
+    try {
+      // eslint-disable-next-line no-unused-vars
+      for await (const kv of it) {
+        t.fail('should not yield results')
+      }
+    } catch (err) {
+      // TODO: ideally, this would be a combined aka aggregate error
+      t.is(err.message, 'end error')
+      t.ok(it._ended, 'ended')
+    }
+  })
+
+  test('for await...of db.iterator() ends on user break', async function (t) {
+    t.plan(2)
+
+    const it = db.iterator()
+
+    // eslint-disable-next-line no-unused-vars, no-unreachable-loop
+    for await (const kv of it) {
+      t.pass('got a chance to break')
+      break
+    }
+
+    t.ok(it._ended, 'ended')
+  })
+
+  test('for await...of db.iterator() with user break and end() error', async function (t) {
+    t.plan(4)
+
+    const it = db.iterator()
+    const end = it._end
+
+    it._end = function (callback) {
+      end.call(this, function (err) {
+        t.ifError(err, 'no real error from end()')
+        callback(new Error('end error'))
+      })
+    }
+
+    try {
+      // eslint-disable-next-line no-unused-vars, no-unreachable-loop
+      for await (const kv of it) {
+        t.pass('got a chance to break')
+        break
+      }
+    } catch (err) {
+      t.is(err.message, 'end error')
+      t.ok(it._ended, 'ended')
+    }
+  })
+}
+
+exports.teardown = function (test, testCommon) {
+  test('teardown', function (t) {
+    t.plan(1)
+
+    db.close(function (err) {
+      t.ifError(err, 'no close() error')
+    })
+  })
+}
+
+exports.all = function (test, testCommon) {
+  exports.setup(test, testCommon)
+  exports.asyncIterator(test, testCommon)
+  exports.teardown(test, testCommon)
+}

--- a/test/async-iterator-test.js
+++ b/test/async-iterator-test.js
@@ -23,7 +23,7 @@ exports.asyncIterator = function (test, testCommon) {
   test('for await...of db.iterator()', async function (t) {
     t.plan(2)
 
-    const it = db.iterator()
+    const it = db.iterator({ keyAsBuffer: false, valueAsBuffer: false })
     const output = []
 
     for await (const [key, value] of it) {

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,7 @@ function suite (options) {
 
   require('./iterator-test').all(test, testCommon)
   require('./iterator-range-test').all(test, testCommon)
+  require('./async-iterator-test').all(test, testCommon)
 
   if (testCommon.seek) {
     require('./iterator-seek-test').all(test, testCommon)

--- a/test/iterator-test.js
+++ b/test/iterator-test.js
@@ -18,39 +18,7 @@ exports.args = function (test, testCommon) {
     iterator.end(t.end.bind(t))
   })
 
-  test('test argument-less iterator#next() throws', function (t) {
-    const iterator = db.iterator()
-    t.throws(
-      iterator.next.bind(iterator),
-      /Error: next\(\) requires a callback argument/,
-      'no-arg iterator#next() throws'
-    )
-    iterator.end(t.end.bind(t))
-  })
-
-  test('test argument-less iterator#end() after next() throws', function (t) {
-    const iterator = db.iterator()
-    iterator.next(function () {
-      t.throws(
-        iterator.end.bind(iterator),
-        /Error: end\(\) requires a callback argument/,
-        'no-arg iterator#end() throws'
-      )
-      iterator.end(t.end.bind(t))
-    })
-  })
-
-  test('test argument-less iterator#end() throws', function (t) {
-    const iterator = db.iterator()
-    t.throws(
-      iterator.end.bind(iterator),
-      /Error: end\(\) requires a callback argument/,
-      'no-arg iterator#end() throws'
-    )
-    iterator.end(t.end.bind(t))
-  })
-
-  test('test iterator#next returns this', function (t) {
+  test('test iterator#next returns this in callback mode', function (t) {
     const iterator = db.iterator()
     const self = iterator.next(function () {})
     t.ok(iterator === self)

--- a/test/self.js
+++ b/test/self.js
@@ -60,6 +60,9 @@ require('./iterator-test').tearDown(test, testCommon)
 require('./iterator-range-test').setUp(test, testCommon)
 require('./iterator-range-test').tearDown(test, testCommon)
 
+require('./async-iterator-test').setup(test, testCommon)
+require('./async-iterator-test').teardown(test, testCommon)
+
 require('./iterator-snapshot-test').setUp(test, testCommon)
 require('./iterator-snapshot-test').tearDown(test, testCommon)
 


### PR DESCRIPTION
Closes #235. You can now do:

```js
try {
  for await (const [key, value] of db.iterator()) {
    console.log(key)
  }
} catch (err) {
  console.error(err)
}
```

Supersedes #338, which was just a proof of concept and we've since dropped support of legacy runtimes (Level/community#98) which now allows us to use async generators across the board.